### PR TITLE
Expose the Link header (Hydra doc)

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -68,9 +68,10 @@ dunglas_api:
 # Nelmio CORS
 nelmio_cors:
     defaults:
-        allow_origin:  ["%cors_allow_origin%"]
-        allow_methods: ["POST", "PUT", "GET", "DELETE", "OPTIONS"]
-        allow_headers: ["content-type", "authorization"]
+        allow_origin:   ["%cors_allow_origin%"]
+        allow_methods:  ["POST", "PUT", "GET", "DELETE", "OPTIONS"]
+        allow_headers:  ["content-type", "authorization"]
+        expose_headers: ["link"]
         max_age:       3600
     paths:
         '^/': ~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Set CORS headers to allow exposing the `Link` header and enable JavaScript clients to retrieve the Hydra API doc.

