### PR TITLE
Remove register_globals option in php.ini

### DIFF
--- a/docker/php/php.ini
+++ b/docker/php/php.ini
@@ -1,5 +1,4 @@
 apc.enable_cli = 1
 date.timezone = UTC
-register_globals = Off
 session.auto_start = Off
 short_open_tag = Off


### PR DESCRIPTION
This option has been removed since PHP 5.4

(Follow-up to #59)