### PR TITLE
Move Action loading after api

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -1,7 +1,7 @@
-app:
-    resource: '@AppBundle/Action/'
-    type:     'annotation'
-
 api:
     resource: '.'
     type:     'api_platform'
+
+app:
+    resource: '@AppBundle/Action/'
+    type:     'annotation


### PR DESCRIPTION
If you add a custom itemOperation, the route will be before in the RouteCollection, and will be used for generating the @id attribute.

This patch move the custom routes after the api generated.
