### PR TITLE
Configure the SQLite database for tests

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -14,3 +14,9 @@ web_profiler:
 
 swiftmailer:
     disable_delivery: true
+
+doctrine:
+    dbal:
+        driver:  "pdo_sqlite"
+        path:    "%kernel.cache_dir%/db.sqlite"
+        charset: "UTF8"


### PR DESCRIPTION
It was forgotten when moving to the structure of Symfony 3+.