### PR TITLE
typo routing.yml

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -4,4 +4,4 @@ api:
 
 app:
     resource: '@AppBundle/Action/'
-    type:     'annotation
+    type:     'annotation'


### PR DESCRIPTION
Fix a typo in `routing.yml`