### PR TITLE
Remove pre-existing PID file before starting apache

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -10,5 +10,6 @@ else
     composer install --prefer-dist --no-dev --no-progress --no-suggest --optimize-autoloader
 fi
 
-# Start Apache with the right permissions
+# Start Apache with the right permissions after removing pre-existing PID file
+rm -f /var/run/apache2/apache2.pid
 exec docker/apache/start_safe_perms -DFOREGROUND


### PR DESCRIPTION
In some cases when stopped, container running apache leaves a PID file behind. As a result, the next time the container starts, apache will stop because of the PID file left in place :

```
httpd (pid 48) already running
```
