### PR TITLE
Solve cache not writable on docker

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -10,6 +10,13 @@ else
     composer install --prefer-dist --no-dev --no-progress --no-suggest --optimize-autoloader --classmap-authoritative
 fi
 
+#get apache user : second word of the first line (from docker/apache/start_safe_perms)
+apache_user=$(head -n 1 /etc/apache2/apache2.conf| cut -d " " -f 2)
+#get apache group : second word of the second line
+apache_group=$(head -n 2 /etc/apache2/apache2.conf| tail -1 |  cut -d " " -f 2)
+
+chown -R $apache_user:$apache_group var
+
 # Start Apache with the right permissions after removing pre-existing PID file
 rm -f /var/run/apache2/apache2.pid
 exec docker/apache/start_safe_perms -DFOREGROUND


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #192
| License       | MIT
| Doc PR        |  x

On docker run, start.sh launch a composer install as root user. Therefore, apache user can't read var/cache/dev content.

To fix it, I get apache user and apache group in `/etc/apache2/apache2.conf` and chown var folder with those values.

