### PR TITLE
Always use the dev env if the SYMFONY_ENV var isn't set

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -4,10 +4,10 @@ set -xe
 # Detect the host IP
 export DOCKER_BRIDGE_IP=$(ip ro | grep default | cut -d' ' -f 3)
 
-if [ "$SYMFONY_ENV" = 'dev' ]; then
-    composer install --prefer-dist --no-progress --no-suggest
-else
+if [ "$SYMFONY_ENV" = 'prod' ]; then
     composer install --prefer-dist --no-dev --no-progress --no-suggest --optimize-autoloader --classmap-authoritative
+else
+    composer install --prefer-dist --no-progress --no-suggest
 fi
 
 # Start Apache with the right permissions after removing pre-existing PID file


### PR DESCRIPTION
Otherwise the `composer install` fail because `dev` is the env by default of Symfony but dev dependencies aren't installed.