### PR TITLE
Update config_prod.yml settings

### DIFF
--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -1,17 +1,11 @@
 imports:
     - { resource: config.yml }
 
-#framework:
-#    validation:
-#        cache: validator.mapping.cache.doctrine.apc
-#    serializer:
-#        cache: serializer.mapping.cache.doctrine.apc
-
-#doctrine:
-#    orm:
-#        metadata_cache_driver: apc
-#        result_cache_driver: apc
-#        query_cache_driver: apc
+doctrine:
+    orm:
+        metadata_cache_driver: apcu
+        result_cache_driver: apcu
+        query_cache_driver: apcu
 
 monolog:
     handlers:


### PR DESCRIPTION
* Remove the comment regarding the framework section (not necessary anymore since 3.2)
* Switch to the apcu driver of Doctrine Cache (best default for PHP 7+ because it doesn't need the compatibility layer of APCu).