### PR TITLE
feature: vendor && cache should anonymous volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,11 +27,11 @@ services:
       SYMFONY_ENV: dev
     volumes:
       - ./:/srv/api-platform
-      - ./var/cache:/srv/api-platform/var/cache
-      - ./var/logs:/srv/api-platform/var/logs
-      - ./var/sessions:/srv/api-platform/var/sessions
       - ./var:/srv/api-platform/var
-      - ./vendor:/srv/api-platform/vendor
+      - /srv/api-platform/var/cache
+      - ./var/logs:/srv/api-platform/var/logs
+      - /srv/api-platform/var/sessions
+      - /srv/api-platform/vendor
       - ./web:/srv/api-platform/web
 
 volumes:


### PR DESCRIPTION
It's useless to install composer in the image then to overwrite with local vendors files that could be out dated.

And this way we will se cache improvement on macOS.