### PR TITLE
Ensure git always uses LF for EOL in shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+*.sh text eol=lf
+docker/apache/start_safe_perms text eol=lf


### PR DESCRIPTION
Should fix #326