### PR TITLE
Dockerfile : Adding required lib pcre

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN buildDeps=" \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         $buildDeps \
+        libpcre3-dev \
         libicu52 \
         zlib1g \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

When I tried `docker-compose up -d` like indicated in the documentation the build fails  with a message like "missing pcre.h ..."
I found that in order to the docker build to succeed we need the libpcre3-dev package in the Dockerfile.