### PR TITLE
Fixed docker for Windows

### DIFF
--- a/api/docker/php/docker-entrypoint.sh
+++ b/api/docker/php/docker-entrypoint.sh
@@ -9,8 +9,8 @@ fi
 if [ "$1" = 'php-fpm' ] || [ "$1" = 'bin/console' ]; then
 	if [ "$APP_ENV" != 'prod' ]; then
 		composer install --prefer-dist --no-progress --no-suggest --no-interaction
-		bin/console assets:install
-		bin/console doctrine:schema:update -f
+		php bin/console assets:install
+		php bin/console doctrine:schema:update -f
 	fi
 
 	# Permissions hack because setfacl does not work on Mac and Windows


### PR DESCRIPTION
This is necessary on Windows otherwise the following error occurs on docker-compose up

```
php_1          | Nothing to install or update
php_1          | Generating autoload files
php_1          | Executing script cache:clear [OK]
php_1          |
php_1          | Executing script assets:install [OK]
': No such file or directoryexecute 'php 