### PR TITLE
Changed var/logs to var/log

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -54,7 +54,7 @@ RUN composer install --prefer-dist --no-dev --no-autoloader --no-scripts --no-pr
 
 COPY . ./
 
-RUN mkdir -p var/cache var/logs var/sessions \
+RUN mkdir -p var/cache var/log var/sessions \
 	&& composer dump-autoload --classmap-authoritative --no-dev \
 	&& composer run-script --no-dev post-install-cmd \
 	&& chmod +x bin/console && sync \

--- a/api/docker/php/docker-entrypoint.sh
+++ b/api/docker/php/docker-entrypoint.sh
@@ -7,7 +7,7 @@ if [ "${1#-}" != "$1" ]; then
 fi
 
 if [ "$1" = 'php-fpm' ] || [ "$1" = 'bin/console' ]; then
-	mkdir -p var/cache var/logs var/sessions
+	mkdir -p var/cache var/log var/sessions
 
 	if [ "$APP_ENV" != 'prod' ]; then
 		composer install --prefer-dist --no-progress --no-suggest --no-interaction


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | not sure
| Fixed tickets | #628
| License       | MIT

To be consistant with sf4, the "logs" folder has been renamed to "log"