### PR TITLE
Update of react-redux-router dependency

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,12 +5,13 @@
   "dependencies": {
     "bootstrap": "^4.0.0",
     "font-awesome": "^4.7.0",
+    "history": "^4.7.2",
     "prop-types": "^15.5.10",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-redux": "^5.0.6",
     "react-router-dom": "^4.2.2",
-    "react-router-redux": "^4.0.8",
+    "react-router-redux": "^5.0.0-alpha.9",
     "redux": "^3.7.2",
     "redux-form": "^7.0.4",
     "redux-thunk": "^2.2.0"

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -4,31 +4,33 @@ import { createStore, combineReducers, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import { reducer as form } from 'redux-form';
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 import createBrowserHistory from 'history/createBrowserHistory';
-import { syncHistoryWithStore, routerReducer as routing } from 'react-router-redux';
+import { ConnectedRouter, routerMiddleware, routerReducer as routing } from 'react-router-redux';
 import 'bootstrap/dist/css/bootstrap.css';
 import 'font-awesome/css/font-awesome.css';
 import registerServiceWorker from './registerServiceWorker';
 // Import your reducers and routes here
 import Welcome from './Welcome';
 
+const history = createBrowserHistory();
+const historyMiddleware = routerMiddleware(history);
+
 const store = createStore(
   combineReducers({routing, form, /* Add your reducers here */}),
   applyMiddleware(thunk),
+  applyMiddleware(historyMiddleware),
 );
-
-const history = syncHistoryWithStore(createBrowserHistory(), store);
 
 ReactDom.render(
   <Provider store={store}>
-    <Router history={history}>
+    <ConnectedRouter history={history}>
       <Switch>
         <Route path="/" component={Welcome} strict={true} exact={true}/>
         {/* Add your routes here */}
         <Route render={() => <h1>Not Found</h1>}/>
       </Switch>
-    </Router>
+    </ConnectedRouter>
   </Provider>,
   document.getElementById('root')
 );

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -5641,9 +5641,13 @@ react-router-dom@^4.2.2:
     react-router "^4.2.0"
     warning "^3.0.0"
 
-react-router-redux@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/react-router-redux/-/react-router-redux-4.0.8.tgz#227403596b5151e182377dab835b5d45f0f8054e"
+react-router-redux@^5.0.0-alpha.9:
+  version "5.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/react-router-redux/-/react-router-redux-5.0.0-alpha.9.tgz#825431516e0e6f1fd93b8807f6bd595e23ec3d10"
+  dependencies:
+    history "^4.7.2"
+    prop-types "^15.6.0"
+    react-router "^4.2.0"
 
 react-router@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
This fixes #675

Would you prefer to go to `^5.0.0-alpha.9` and explicitly require `"history": "^4.7.2"` then update the code of the index.js to what I've done based on [the documentation
](https://github.com/ReactTraining/react-router/tree/master/packages/react-router-redux)

Or would you want to go to `react-router` v3 ? 