### PR TITLE
Ensure that .env is always loaded in dev

### DIFF
--- a/api/public/index.php
+++ b/api/public/index.php
@@ -7,15 +7,16 @@ use Symfony\Component\HttpFoundation\Request;
 
 require __DIR__.'/../vendor/autoload.php';
 
+$env = $_SERVER[‘APP_ENV’] ?? ‘dev’;
+
 // The check is to ensure we don't use .env in production
-if (!isset($_SERVER['APP_ENV'])) {
+if ($env === ‘dev’) {
     if (!class_exists(Dotenv::class)) {
         throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
     }
     (new Dotenv())->load(__DIR__.'/../.env');
 }
 
-$env = $_SERVER['APP_ENV'] ?? 'dev';
 $debug = $_SERVER['APP_DEBUG'] ?? ('prod' !== $env);
 
 if ($debug) {


### PR DESCRIPTION
I ran into this because APP_ENV is for whatever reason already set.
This change will lead to less code and increased readability.