### PR TITLE
Fix NelmioCors regex

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -17,7 +17,7 @@ DATABASE_URL=postgres://api-platform:!ChangeMe!@db/api
 ###< doctrine/doctrine-bundle ###
 
 ###> nelmio/cors-bundle ###
-CORS_ALLOW_ORIGIN=^https?://localhost:?[0-9]*$
+CORS_ALLOW_ORIGIN=^https?://localhost(:[0-9]+)?$
 ###< nelmio/cors-bundle ###
 
 VARNISH_URL=http://cache-proxy

--- a/api/.env.dist
+++ b/api/.env.dist
@@ -17,7 +17,7 @@ DATABASE_URL=postgres://api-platform:!ChangeMe!@db/api
 ###< doctrine/doctrine-bundle ###
 
 ###> nelmio/cors-bundle ###
-CORS_ALLOW_ORIGIN=^https?://localhost:?[0-9]*$
+CORS_ALLOW_ORIGIN=^https?://localhost(:[0-9]+)?$
 ###< nelmio/cors-bundle ###
 
 VARNISH_URL=http://cache-proxy


### PR DESCRIPTION
The current regex allows domains like `http://localhost8000` (missing `:`). This PR allows only `localhost` followed by a port.

Reported by @Mathieudewet.
