### PR TITLE
Upgrade to postgres 10

### DIFF
--- a/api/config/packages/doctrine.yaml
+++ b/api/config/packages/doctrine.yaml
@@ -9,7 +9,7 @@ doctrine:
     dbal:
         # configure these for your database server
         driver: 'pdo_pgsql'
-        server_version: '9.6'
+        server_version: '10'
 
         # With Symfony 3.3, remove the `resolve:` prefix
         url: '%env(resolve:DATABASE_URL)%'

--- a/api/helm/api/requirements.lock
+++ b/api/helm/api/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.11.0
-digest: sha256:461a83f20429597b7b3f2d38bbad7f5cedb6c26d57af5e0cc02f87147ae28acb
-generated: 2018-05-04T19:06:48.914008844+02:00
+  version: 0.18.1
+digest: sha256:d3a1c2738398c0657d885ca0451349f83086936b7a853aeca3d117f93260516d
+generated: 2018-10-01T22:29:12.850677078+07:00

--- a/api/helm/api/requirements.yaml
+++ b/api/helm/api/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: postgresql
-  version: 0.11.0
+  version: 0.18.1
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: postgresql.enabled

--- a/api/helm/api/values.yaml
+++ b/api/helm/api/values.yaml
@@ -39,6 +39,7 @@ ingress:
 
 postgresql:
   enabled: true
+  imageTag: 10-alpine
   # If bringing your own PostgreSQL, the full uri to use
   #url: postgres://api-platform:!ChangeMe!@example.com/api
   postgresUser: api-platform

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
 
   db:
     # In production, you may want to use a managed database service
-    image: postgres:9.6-alpine
+    image: postgres:10-alpine
     environment:
       - POSTGRES_DB=api
       - POSTGRES_USER=api-platform


### PR DESCRIPTION
Previously this was downgraded to 9.6 with PR https://github.com/api-platform/api-platform/pull/532.

Doctrine now supports postgresql v10. Currently Heroku defaults to giving people v10 databases so I think it's a good idea to upgrade at this point as people setting up using the Heroku tutorials will eventually experience problems when doing things like updating their schemas.