### PR TITLE
Use again prestissimo

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -56,6 +56,9 @@ COPY docker/php/conf.d/api-platform.ini $PHP_INI_DIR/conf.d/api-platform.ini
 
 # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
 ENV COMPOSER_ALLOW_SUPERUSER=1
+RUN set -eux; \
+	composer global require "hirak/prestissimo:^0.3" --prefer-dist --no-progress --no-suggest --classmap-authoritative; \
+	composer clear-cache
 ENV PATH="${PATH}:/root/.composer/vendor/bin"
 
 WORKDIR /srv/api


### PR DESCRIPTION
This reverts commit cdc399837e05144a32ad0a09c5743edf9f558dbf.
It's because the prefetching of Symfony Flex is only done when the flag `--no-scripts` is not set.
But it needs to be set because the cache clear can't be done (`Could not open input file: bin/console`).