### PR TITLE
Use Symfony Flex

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -56,6 +56,8 @@ COPY docker/php/conf.d/api-platform.ini $PHP_INI_DIR/conf.d/api-platform.ini
 
 # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
 ENV COMPOSER_ALLOW_SUPERUSER=1
+# install Symfony Flex globally to speed up download of Composer packages (parallelized prefetching)
+RUN composer global require "symfony/flex" --prefer-dist --no-progress --no-suggest --classmap-authoritative
 ENV PATH="${PATH}:/root/.composer/vendor/bin"
 
 WORKDIR /srv/api


### PR DESCRIPTION
Install Symfony Flex globally to speed up download of Composer packages (parallelized prefetching).