### PR TITLE
Update database connection condition in Docker container

### DIFF
--- a/api/docker/php/docker-entrypoint.sh
+++ b/api/docker/php/docker-entrypoint.sh
@@ -27,6 +27,7 @@ if [ "$1" = 'php-fpm' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
 	done
 
 	if [ "$APP_ENV" != 'prod' ]; then
+	    bin/console doctrine:database:create --no-interaction --if-not-exists
 		bin/console doctrine:schema:update --force --no-interaction
 	fi
 fi

--- a/api/docker/php/docker-entrypoint.sh
+++ b/api/docker/php/docker-entrypoint.sh
@@ -22,7 +22,7 @@ if [ "$1" = 'php-fpm' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
 	fi
 
 	echo "Waiting for db to be ready..."
-	until bin/console doctrine:query:sql "SELECT 1" > /dev/null 2>&1; do
+	until ping -c1 db:5432 &>/dev/null; do
 		sleep 1
 	done
 


### PR DESCRIPTION
Using `docker-composer` I realized that the creation of the database was not automatic.

This PR adds the creation of the database if it does not exist and also replaces the condition to wait until the Postgre server is accessible.

```
bin/console doctrine:database:create --no-interaction --if-not-exists
```

This command only creates the database if it does not already exist.

However, if the database does not exist, then the `bin/console doctrine:query:sql condition "SELECT 1"` does not work:
```
Message: "An exception occurred in driver: SQLSTATE[08006][7] FATAL: database "db_name" does not exist"
```

That's why I replaced the condition with a simple curl request:
```
ping -c1 db:5432&>/dev/null
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 