### PR TITLE
Upgrade to Varnish 6.2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -38,6 +38,10 @@ indent_size = 4
 indent_style = tab
 indent_size = 4
 
+[*.vcl]
+indent_style = space
+indent_size = 2
+
 [*.xml]
 indent_style = space
 indent_size = 4

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -6,7 +6,7 @@
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG PHP_VERSION=7.3
 ARG NGINX_VERSION=1.15
-ARG VARNISH_VERSION=6.0
+ARG VARNISH_VERSION=6.2
 
 
 # "php" stage

--- a/api/docker/varnish/conf/default.vcl
+++ b/api/docker/varnish/conf/default.vcl
@@ -25,12 +25,58 @@ acl invalidators {
   "192.168.0.0"/16;
 }
 
-sub vcl_backend_response {
-  # Ban lurker friendly header
-  set beresp.http.url = bereq.url;
+sub vcl_recv {
+  if (req.restarts > 0) {
+    set req.hash_always_miss = true;
+  }
 
-  # Add a grace in case the backend is down
-  set beresp.grace = 1h;
+  # Remove the "Forwarded" HTTP header if exists (security)
+  unset req.http.forwarded;
+
+  # To allow API Platform to ban by cache tags
+  if (req.method == "BAN") {
+    if (client.ip !~ invalidators) {
+      return (synth(405, "Not allowed"));
+    }
+
+    if (req.http.ApiPlatform-Ban-Regex) {
+      ban("obj.http.Cache-Tags ~ " + req.http.ApiPlatform-Ban-Regex);
+
+      return (synth(200, "Ban added"));
+    }
+
+    return (synth(400, "ApiPlatform-Ban-Regex HTTP header must be set."));
+  }
+
+  # For health checks
+  if (req.method == "GET" && req.url == "/healthz") {
+    return (synth(200, "OK"));
+  }
+}
+
+sub vcl_hit {
+  if (obj.ttl >= 0s) {
+    # A pure unadulterated hit, deliver it
+    return (deliver);
+  }
+
+  if (std.healthy(req.backend_hint)) {
+    # The backend is healthy
+    # Fetch the object from the backend
+    return (restart);
+  }
+
+  # No fresh object and the backend is not healthy
+  if (obj.ttl + obj.grace > 0s) {
+    # Deliver graced object
+    # Automatically triggers a background fetch
+    return (deliver);
+  }
+
+  # No valid object to deliver
+  # No healthy backend to handle request
+  # Return error
+  return (synth(503, "API is down"));
 }
 
 sub vcl_deliver {
@@ -40,49 +86,10 @@ sub vcl_deliver {
   unset resp.http.Cache-Tags;
 }
 
-sub vcl_recv {
-  # Remove the "Forwarded" HTTP header if exists (security)
-  unset req.http.forwarded;
+sub vcl_backend_response {
+  # Ban lurker friendly header
+  set beresp.http.url = bereq.url;
 
-  # To allow API Platform to ban by cache tags
-  if (req.method == "BAN") {
-    if (client.ip !~ invalidators) {
-      return(synth(405, "Not allowed"));
-    }
-
-    if (req.http.ApiPlatform-Ban-Regex) {
-      ban("obj.http.Cache-Tags ~ " + req.http.ApiPlatform-Ban-Regex);
-
-      return(synth(200, "Ban added"));
-    }
-
-    return(synth(400, "ApiPlatform-Ban-Regex HTTP header must be set."));
-  }
-
-  # For health checks
-  if (req.method == "GET" && req.url == "/healthz") {
-    return(synth(200, "OK"));
-  }
-}
-
-sub vcl_hit {
-  if (obj.ttl >= 0s) {
-    # A pure unadulterated hit, deliver it
-    return (deliver);
-  }
-  if (std.healthy(req.backend_hint)) {
-    # The backend is healthy
-    # Fetch the object from the backend
-    return (miss);
-  }
-  # No fresh object and the backend is not healthy
-  if (obj.ttl + obj.grace > 0s) {
-    # Deliver graced object
-    # Automatically triggers a background fetch
-    return (deliver);
-  }
-  # No valid object to deliver
-  # No healthy backend to handle request
-  # Return error
-  return (synth(503, "API is down"));
+  # Add a grace in case the backend is down
+  set beresp.grace = 1h;
 }


### PR DESCRIPTION
https://varnish-cache.org/docs/6.2/whats-new/upgrading-6.2.html

> `return(miss)` from `vcl_hit{}` is now removed. An option for implementing similar functionality is:
>
> * `return (restart)` from `vcl_hit{}`
> * in `vcl_recv{}` for the restart (when `req.restarts` has increased), `set req.hash_always_miss = true;`.

https://varnish-cache.org/docs/6.2/whats-new/changes-6.2.html#other-changes-to-vcl

> `return(miss)` from `vcl_hit{}` did never work as intended for the common case (it actually turned into a pass), so we now removed it and changed the `builtin.vcl`.