### PR TITLE
Dotenv instance is constructed with unnecessary argument

### DIFF
--- a/api/config/bootstrap.php
+++ b/api/config/bootstrap.php
@@ -12,7 +12,7 @@ if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
     throw new RuntimeException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
 } else {
     // load all the .env files
-    (new Dotenv(false))->loadEnv(dirname(__DIR__).'/.env');
+    (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
 }
 
 $_SERVER += $_ENV;


### PR DESCRIPTION
\Symfony\Component\Dotenv\Dotenv has no constructor that could take arguments