### PR TITLE
Fixes proxy error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,6 +118,7 @@ services:
       - admin
       - api
       - cache-proxy
+      - mercure
     ports:
       - "443:443"
       - "444:444"


### PR DESCRIPTION
Fixes that error:
```
h2-proxy_1     | 2019/06/16 13:33:45 [emerg] 1#1: host not found in upstream "mercure" in /etc/nginx/conf.d/default.conf:76
h2-proxy_1     | nginx: [emerg] host not found in upstream "mercure" in /etc/nginx/conf.d/default.conf:76
sonda_h2-proxy_1 exited with code 1

```
