### PR TITLE
Helm: Error if --set varnish.enabled=false - Logical error

### DIFF
--- a/api/helm/api/templates/configmap.yaml
+++ b/api/helm/api/templates/configmap.yaml
@@ -12,7 +12,7 @@ data:
   env: {{ .Values.php.env | quote }}
   debug: {{ .Values.php.debug | quote }}
   cors-allow-origin: {{ .Values.php.corsAllowOrigin | quote }}
-  varnish-url: {{ if .Values.varnish.enabled }}http://varnish{{ else }}{{ .Values.varnish.url | quote }}{{ end }}
+  varnish-url: {{ if .Values.varnish.url }}{{ .Values.varnish.url | quote }}{{ else }}http://varnish{{ end }}
   trusted-hosts: {{ .Values.php.trustedHosts | quote }}
   trusted-proxies: {{ join "," .Values.php.trustedProxies }}
   mercure-publish-url: {{ .Values.mercure.publishUrl | quote }}


### PR DESCRIPTION
Hey 👋 ,
i tried to install the helm charts without varnish --set varnish.enabled=false.

This caused into an error: 

```
Error: validation failed: error validating "": error validating data: unknown object type "nil" in ConfigMap.data.varnish-url
```

It's more like a logical error.  If varnish is not enabled, it tries to use the varnish.url variable, which is not set, because i don't need it.

As a general question, is it better to use the if varnish.enabled block complete around the configmap key "varnish-url"?

Example:

```
{{ if .Values.varnish.enabled }}varnish-url: {{ if .Values.varnish.url }}{{ .Values.varnish.url | quote }}{{ else }}http://varnish{{ end }}{{ end }}
```

In this case, it  need some improvements in other files, because some parts depends that the config file varnish-url exists (php-deployment).

Greetings, JB