### PR TITLE
Remove quotes from TRUSTED_HOSTS

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -20,7 +20,7 @@ VARNISH_URL=http://cache-proxy
 APP_ENV=dev
 APP_SECRET=!ChangeMe!
 TRUSTED_PROXIES=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
-TRUSTED_HOSTS='^localhost|api$'
+TRUSTED_HOSTS=^localhost|api$
 ###< symfony/framework-bundle ###
 
 ###> doctrine/doctrine-bundle ###


### PR DESCRIPTION
Maybe I'm missing something, but this just ends up with single quotes in the regex, so it won't match any hostnames (on Windows at least).

See [CORS_ALLOW_ORIGIN](https://github.com/api-platform/api-platform/blob/767e635967019577952df7592725969c37b108f4/api/.env#L34) in the same file for an example of regex, and no other values in the `.env` are wrapped in single quotes.