### PR TITLE
Create PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,8 +5,8 @@
 | BC breaks?    | no
 | Deprecations? | no
 | Tests pass?   | yes
-| Fixed tickets | #abcd, #xxxx
+| Fixed tickets | #1234, #5678
 | License       | MIT
-| Doc PR        | api-platform/docs#xxxx
+| Doc PR        | api-platform/doc#1234
 
-<!-- Please note that commits may need to be squashed before the PR is made -->
+<!-- Please note that commits need to be squashed before the PR is made -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-| Question             | Answer
+| Q             | A
 | ------------- | ---
 | Bug fix?      | yes/no
 | New feature?  | yes/no

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+| Question             | Answer
+| ------------- | ---
+| Bug fix?      | yes/no
+| New feature?  | yes/no
+| BC breaks?    | no
+| Deprecations? | no
+| Tests pass?   | yes
+| Fixed tickets | #abcd, #xxxx
+| License       | MIT
+| Doc PR        | api-platform/docs#xxxx
+
+<!-- Please note that commits may need to be squashed before the PR is made -->


### PR DESCRIPTION
Instead of enforcing a mandatory header [here](https://github.com/api-platform/api-platform/blob/master/.github/CONTRIBUTING.md#sending-a-pull-request), just create a pull request template instead.

| Question             | Answer
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

#1270 depends on this, please review @dunglas