### PR TITLE
Switch to the official varnish Docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ jobs:
         # wait for postgresql to shutdown
         - while sudo lsof -Pi :5432 -sTCP:LISTEN -t; do sleep 1; done
       script:
-        - git submodule add https://github.com/api-platform/docker-compose-prod
+        - wget -O - https://github.com/api-platform/docker-compose-prod/archive/master.tar.gz | tar -xzf - && mv docker-compose-prod-master docker-compose-prod
         - docker-compose -f docker-compose-prod/docker-compose.build.yml pull --ignore-pull-failures
         - docker-compose -f docker-compose-prod/docker-compose.build.yml build --pull
         - mkdir -p docker-compose-prod/docker/nginx-proxy/vhost.d

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -6,7 +6,7 @@
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG PHP_VERSION=7.3
 ARG NGINX_VERSION=1.17
-ARG VARNISH_VERSION=6.2
+ARG VARNISH_VERSION=6.3
 
 
 # "php" stage
@@ -119,6 +119,8 @@ COPY --from=api_platform_php /srv/api/public ./
 
 # "varnish" stage
 # does not depend on any of the above stages, but placed here to keep everything in one Dockerfile
-FROM cooptilleuls/varnish:${VARNISH_VERSION}-alpine AS api_platform_varnish
+FROM varnish:${VARNISH_VERSION} AS api_platform_varnish
 
-COPY docker/varnish/conf/default.vcl /usr/local/etc/varnish/default.vcl
+COPY docker/varnish/conf/default.vcl /etc/varnish/default.vcl
+
+CMD ["varnishd", "-F", "-f", "/etc/varnish/default.vcl", "-p", "http_resp_hdr_len=65536", "-p", "http_resp_size=98304"]

--- a/api/docker/nginx/conf.d/default.conf
+++ b/api/docker/nginx/conf.d/default.conf
@@ -13,8 +13,13 @@ server {
         #set $upstream_host php;
         #fastcgi_pass $upstream_host:9000;
 
+        # Increase the buffer size to handle large cache invalidation headers
+        fastcgi_buffer_size 32k;
+        fastcgi_buffers 32 4k;
+
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
+
         # When you are using symlinks to link the document root to the
         # current version of your application, you should pass the real
         # application path instead of the path to the symlink to PHP

--- a/api/helm/api/templates/varnish-deployment.yaml
+++ b/api/helm/api/templates/varnish-deployment.yaml
@@ -24,7 +24,7 @@ spec:
           image: "{{ .Values.varnish.repository }}:{{ .Values.varnish.tag }}"
           imagePullPolicy: {{ .Values.varnish.pullPolicy }}
           command: ["varnishd"]
-          args: ["-F", "-f", "/usr/local/etc/varnish/default.vcl", "-p", "http_resp_hdr_len=65536", "-p", "http_resp_size=98304"]
+          args: ["-F", "-f", "/etc/varnish/default.vcl", "-p", "http_resp_hdr_len=65536", "-p", "http_resp_size=98304"]
           ports:
             - containerPort: 80
           livenessProbe:


### PR DESCRIPTION
Since there's an [official `varnish` Docker image](https://hub.docker.com/_/varnish) now, we should use it and abandon maintaining [our own image](https://hub.docker.com/r/cooptilleuls/varnish).