### PR TITLE
Make migrations also work if using mysql as the database.

### DIFF
--- a/api/src/Migrations/Version20190819120152.php
+++ b/api/src/Migrations/Version20190819120152.php
@@ -16,17 +16,17 @@ final class Version20190819120152 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
+        $platformName = $this->connection->getDatabasePlatform()->getName();
+        $this->skipIf('postgresql' !== $platformName && 'mysql' !== $platformName, 'Migration can only be executed safely on \'postgresql\' or \'mysql\'.');
 
-        $this->addSql('CREATE SEQUENCE greeting_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
-        $this->addSql('CREATE TABLE greeting (id INT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE TABLE greeting (id SERIAL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id))');
     }
 
     public function down(Schema $schema): void
     {
-        $this->abortIf('postgresql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'postgresql\'.');
+        $platformName = $this->connection->getDatabasePlatform()->getName();
+        $this->skipIf('postgresql' !== $platformName && 'mysql' !== $platformName, 'Migration can only be executed safely on \'postgresql\' or \'mysql\'.');
 
-        $this->addSql('DROP SEQUENCE greeting_id_seq CASCADE');
         $this->addSql('DROP TABLE greeting');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

If switching to mysql as database instead of postgresql (the default), this migration would abort with a non-zero returncode. That would make the php container fail, and not being able to serve the api. 
This PR will make it possible to use mysql and still have the example 'greeting'-table created and working. 
