### PR TITLE
Fix certificates by adding them to the local trust store.

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -38,7 +38,7 @@ CORS_ALLOW_ORIGIN=^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$
 
 ###> symfony/mercure-bundle ###
 # See https://symfony.com/doc/current/mercure.html#configuration
-MERCURE_PUBLISH_URL=http://mercure/.well-known/mercure
+MERCURE_PUBLISH_URL=https://mercure/.well-known/mercure
 # The default token is signed with the secret key: !ChangeMe!
 MERCURE_JWT_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXJjdXJlIjp7InB1Ymxpc2giOltdfX0.Oo0yg7y4yMa1vr_bziltxuTCqb8JVHKxp-f_FwwOim0
 ###< symfony/mercure-bundle ###

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,9 +20,13 @@ services:
       start_period: 30s
     depends_on:
       - db
+      - dev-tls
     volumes:
       - ./api:/srv/api:rw,cached
       - ./api/docker/php/conf.d/api-platform.dev.ini/:/usr/local/etc/php/conf.d/api-platform.ini
+      - dev-localshare-ca-certificates:/usr/local/share/ca-certificates:ro
+      - dev-share-ca-certificates:/usr/share/ca-certificates:ro
+      - dev-ssl-ca-certificates:/etc/ssl/certs:ro
       # if you develop on Linux, you may use a bind-mounted host directory instead
       # - ./api/var:/srv/api/var:rw
 
@@ -124,11 +128,15 @@ services:
         published: 444
         protocol: tcp
 
+  # These certificates MUST NOT be used in production
   dev-tls:
     build:
       context: ./docker/dev-tls
     volumes:
       - dev-certs:/certs:rw
+      - dev-ssl-ca-certificates:/etc/ssl/certs:ro
+      - dev-share-ca-certificates:/usr/share/ca-certificates:ro
+      - dev-localshare-ca-certificates:/usr/local/share/ca-certificates:ro
     ports:
       - target: 80
         published: 80
@@ -137,3 +145,6 @@ services:
 volumes:
   db-data: {}
   dev-certs: {}
+  dev-ssl-ca-certificates: {}
+  dev-share-ca-certificates: {}
+  dev-localshare-ca-certificates: {}

--- a/docker/dev-tls/Dockerfile
+++ b/docker/dev-tls/Dockerfile
@@ -10,6 +10,7 @@ FROM nginx:${NGINX_VERSION}-alpine
 # persistent / runtime deps
 RUN apk add --no-cache \
 		nss-tools \
+		ca-certificates \
 	;
 
 WORKDIR /certs
@@ -18,11 +19,15 @@ ARG MKCERT_VERSION=1.4.1
 RUN set -eux; \
 	wget -O /usr/local/bin/mkcert https://github.com/FiloSottile/mkcert/releases/download/v$MKCERT_VERSION/mkcert-v$MKCERT_VERSION-linux-amd64; \
 	chmod +x /usr/local/bin/mkcert; \
-	mkcert --cert-file localhost.crt --key-file localhost.key localhost; \
+	mkcert -install; \
+	mkcert --cert-file localhost.crt --key-file localhost.key localhost mercure; \
+	update-ca-certificates; \
 	# the file must be named server.pem - the default certificate path in webpack-dev-server
 	cat localhost.key localhost.crt > server.pem
 
 VOLUME /certs
+VOLUME /etc/ssl/certs
+VOLUME /usr/local/share/ca-certificates
 
 # add redirect from http://localhost to https://localhost
 RUN set -eux; \


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes 
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #1405 #1410 
| License       | MIT
| Doc PR        | N/A

Adds the certificates to the local trust store.
Additionally alert the user that these certificates should not be used in production 
by adding a comment in the docker-compose file.

Not really found of the multiple volumes, but did not found a better way.
Another solution would be to patch Mercure to allow 80 port.
