### PR TITLE
Keep LICENSE in archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,5 @@ composer.lock text eol=lf merge=ours
 
 .github export-ignore
 .travis.yml export-ignore
-LICENSE export-ignore
 README.md export-ignore
 update-deps.sh export-ignore


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #1413 
| License       | MIT
| Doc PR        | na

I guess that this line skips the License in the archive.
