### PR TITLE
Fix SSL_ERROR_RX_RECORD_TOO_LONG

### DIFF
--- a/admin/docker/nginx/conf.d/default.conf
+++ b/admin/docker/nginx/conf.d/default.conf
@@ -1,5 +1,10 @@
 server {
+    listen 443 ssl;
+
     root /usr/src/admin/build;
+
+    ssl_certificate /usr/src/client/node_modules/webpack-dev-server/ssl/localhost.crt;
+    ssl_certificate_key /usr/src/client/node_modules/webpack-dev-server/ssl/localhost.key;
 
     location / {
         try_files $uri /index.html;

--- a/client/docker/nginx/conf.d/default.conf
+++ b/client/docker/nginx/conf.d/default.conf
@@ -1,5 +1,10 @@
 server {
+    listen 443 ssl;
+
     root /usr/src/client/build;
+
+    ssl_certificate /usr/src/client/node_modules/webpack-dev-server/ssl/localhost.crt;
+    ssl_certificate_key /usr/src/client/node_modules/webpack-dev-server/ssl/localhost.key;
 
     location / {
         try_files $uri /index.html;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT

Not sure it's the right fix...

I have an `SSL_ERROR_RX_RECORD_TOO_LONG` error while using following configuration:
```yaml
# docker-compose.yml
services:
  client:
    build:
      target: api_platform_client_nginx
    ports:
      - target: 80
        published: 443
        protocol: tcp
```

But it's working with this PR fixes and the following configuration:
```yaml
# docker-compose.yml
services:
  client:
    build:
      target: api_platform_client_nginx
    ports:
      - target: 443
        published: 443
        protocol: tcp
```