### PR TITLE
Helm, use replica count of PHP for php-deployment

### DIFF
--- a/api/helm/api/templates/php-deployment.yaml
+++ b/api/helm/api/templates/php-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- include "api.labels" $data | nindent 4 }}
 spec:
-  replicas: {{ .Values.nginx.replicaCount }}
+  replicas: {{ .Values.php.replicaCount }}
   selector:
     matchLabels:
       {{- include "api.selectorLabels" $data | nindent 6 }}


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT
Update the php deployment to use the php replica count value instead of the Nginx one. 