### PR TITLE
[Kubernetes] Execute DB migration in initContainer

### DIFF
--- a/api/helm/api/templates/php-deployment.yaml
+++ b/api/helm/api/templates/php-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         - name: init-php
-          image: {{ .Values.php.image.repository }}:{{ .Values.php.image.tag }}
+          image: "{{ .Values.php.image.repository }}:{{ .Values.php.image.tag | default .Chart.AppVersion }}"
           command: ['/bin/bash', '-c']
           args: ['bin/console doctrine:migrations:migrate --no-interaction']
           env:

--- a/api/helm/api/templates/php-deployment.yaml
+++ b/api/helm/api/templates/php-deployment.yaml
@@ -24,6 +24,27 @@ spec:
       serviceAccountName: {{ include "api.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: init-php
+          image: {{ .Values.php.image.repository }}:{{ .Values.php.image.tag }}
+          command: ['/bin/bash', '-c']
+          args: ['bin/console doctrine:migrations:migrate --no-interaction']
+          env:
+            - name: APP_DEBUG
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $fullName }}
+                  key: debug
+            - name: APP_ENV
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $fullName }}
+                  key: env
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $fullName }}
+                  key: database-url
       containers:
         - name: {{ .Chart.Name }}-{{ $name }}
           image: "{{ .Values.php.image.repository }}:{{ .Values.php.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | yes <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #... <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT
| Doc PR        | api-platform/docs#...

When the PHP application is deployed, after 120 seconds the `readinessProbe` kicks in. `periodSeconds` is defined as `3` seconds, and the default value for `failureTreshold` is `3`, which means that 9 seconds after the probes kick in, the `pod` should be ready. If not, a `Failure` is registered and the `pod` will restart.

When the pod is started, the database migration is executed (defined in `/api/docker/php/docker-entrypoint.sh` in the codebase). The migration has to be done within the 129 seconds time limit, else the `pod` will restart during the migration.

This PR introduces uses the [init container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) to run the DB migration. When the `init container's` task is finished (in this case when the database migration is executed), the normal PHP container will start. To keep everything working on DEV the db migration will be executed again in the `entry-point` script, but since there's no migration to execute it will be done quick.

This way, the length of the database migration does not effect the readiness of the pod, while not having to touch any of the `readinessProbe` variables.

I'm not sure whether `APP_DEBUG` and `APP_ENV` need to be defined in this `initContainer`, but I wanted to make sure that the environment is the same as the one that is going live.




