### PR TITLE
Add opcache preload config for Production.

### DIFF
--- a/api/docker/php/conf.d/api-platform.prod.ini
+++ b/api/docker/php/conf.d/api-platform.prod.ini
@@ -10,3 +10,5 @@ opcache.memory_consumption = 256
 opcache.validate_timestamps = 0
 realpath_cache_size = 4096K
 realpath_cache_ttl = 600
+opcache.preload_user=www-data
+opcache.preload=/srv/api/var/cache/prod/App_KernelProdContainer.preload.php


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This adds opcache preload config for the prod php.ini as described [here](https://symfony.com/doc/current/performance.html#use-the-opcache-class-preloading)
It would be great to see this in 2.5.7 but I have created the PR against master because technically it's a new feature I guess.