### PR TITLE
Fix volume mapping with Docker host

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -10,7 +10,9 @@ ARG NGINX_VERSION=1.17
 # "development" stage
 FROM node:${NODE_VERSION}-alpine AS api_platform_admin_development
 
-WORKDIR /usr/src/admin
+# create and define the node_modules's cache directory
+RUN mkdir -p /usr/src/cache
+WORKDIR /usr/src/cache
 
 # prevent the reinstallation of node modules at every changes in the source code
 COPY package.json yarn.lock ./
@@ -23,13 +25,16 @@ RUN set -eux; \
 	yarn install; \
 	apk del .gyp
 
-COPY . ./
+WORKDIR /usr/src/admin
 
-VOLUME /usr/src/admin/node_modules
+COPY . ./
 
 ENV HTTPS true
 
-CMD ["yarn", "start"]
+COPY docker/node/start-cmd.sh /usr/local/bin/start-cmd
+RUN chmod +x /usr/local/bin/start-cmd
+
+CMD ["start-cmd"]
 
 
 # "build" stage

--- a/admin/docker/node/start-cmd.sh
+++ b/admin/docker/node/start-cmd.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+cp -r /usr/src/cache/node_modules/. /usr/src/admin/node_modules/
+
+exec yarn start

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -10,22 +10,27 @@ ARG NGINX_VERSION=1.17
 # "development" stage
 FROM node:${NODE_VERSION}-alpine AS api_platform_client_development
 
-WORKDIR /usr/src/client
-
 RUN yarn global add @api-platform/client-generator
+
+# create and define the node_modules's cache directory
+RUN mkdir -p /usr/src/cache
+WORKDIR /usr/src/cache
 
 # prevent the reinstallation of node modules at every changes in the source code
 COPY package.json yarn.lock ./
 RUN set -eux; \
 	yarn install
 
-COPY . ./
+WORKDIR /usr/src/client
 
-VOLUME /usr/src/client/node_modules
+COPY . ./
 
 ENV HTTPS true
 
-CMD ["yarn", "start"]
+COPY docker/node/start-cmd.sh /usr/local/bin/start-cmd
+RUN chmod +x /usr/local/bin/start-cmd
+
+CMD ["start-cmd"]
 
 
 # "build" stage

--- a/client/docker/node/start-cmd.sh
+++ b/client/docker/node/start-cmd.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+cp -r /usr/src/cache/node_modules/. /usr/src/client/node_modules/
+
+exec yarn start


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #1155
| License       | MIT
| Doc PR        | api-platform/docs#...

Implemented the changes mentioned in https://stackoverflow.com/a/52092711/2657607 to fix #1155. 

Tested on macOS 10.14.6 with Docker Desktop 2.3.0.4.

`node_modules` directories are now visible in the IDE:

<img src="https://user-images.githubusercontent.com/1837678/89704583-fcb42000-d922-11ea-81cd-ca5003c5d503.png" width="300" />

- I don't know how to add tests for the docker build
- I don't think this breaks backward compatibility but this PR removes the `VOLUME` from the "development" stages of the node Dockerfiles
