### PR TITLE
add more logs to docker php enttrypoint

### DIFF
--- a/api/docker/php/docker-entrypoint.sh
+++ b/api/docker/php/docker-entrypoint.sh
@@ -27,9 +27,19 @@ if [ "$1" = 'php-fpm' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
 	fi
 
 	echo "Waiting for db to be ready..."
-	until bin/console doctrine:query:sql "SELECT 1" > /dev/null 2>&1; do
+	ATTEMPTS_LEFT_TO_REACH_DATABASE=60
+	until [ $ATTEMPTS_LEFT_TO_REACH_DATABASE -eq 0 ] || bin/console doctrine:query:sql "SELECT 1" > /dev/null 2>&1; do
 		sleep 1
+		ATTEMPTS_LEFT_TO_REACH_DATABASE=$((ATTEMPTS_LEFT_TO_REACH_DATABASE-1))
+		echo "Still waiting for db to be ready... Or maybe the db is not reachable. $ATTEMPTS_LEFT_TO_REACH_DATABASE attempts left"
 	done
+
+	if [ $ATTEMPTS_LEFT_TO_REACH_DATABASE -eq 0 ]; then
+		echo "The db is not up or not reachable"
+		exit 1
+	else
+	   echo "The db is now ready and reachable"
+	fi
 
 	if ls -A src/Migrations/*.php > /dev/null 2>&1; then
 		bin/console doctrine:migrations:migrate --no-interaction


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #... <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT
| Doc PR        | api-platform/docs#...

We had some difficulties debuging an app. The error was that the php container didn't have the rights to reach the database in AWS (wrong security group documentation). 
The logs didn't help us enought to find the issue quickly. I suggest adding these two lines to help other people that may have the same problem to find out what's going on more easily.
