### PR TITLE
fix Since symfony/dotenv 5.1: Passing a boolean to the constructor of "Symfony\Component\Dotenv\Dotenv" is deprecated, use "Dotenv::usePutenv()"

### DIFF
--- a/api/config/bootstrap.php
+++ b/api/config/bootstrap.php
@@ -11,10 +11,10 @@ if (!class_exists(Dotenv::class)) {
 // Load cached env vars if the .env.local.php file exists
 // Run "composer dump-env prod" to create it (requires symfony/flex >=1.2)
 if (is_array($env = @include dirname(__DIR__).'/.env.local.php') && (!isset($env['APP_ENV']) || ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? $env['APP_ENV']) === $env['APP_ENV'])) {
-    (new Dotenv(false))->populate($env);
+    (new Dotenv())->usePutenv(false)->populate($env);
 } else {
     // load all the .env files
-    (new Dotenv(false))->loadEnv(dirname(__DIR__).'/.env');
+    (new Dotenv())->usePutenv(false)->loadEnv(dirname(__DIR__).'/.env');
 }
 
 $_SERVER += $_ENV;


### PR DESCRIPTION
fix Since symfony/dotenv 5.1: Passing a boolean to the constructor of "Symfony\Component\Dotenv\Dotenv" is deprecated, use "Dotenv::usePutenv()"

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tickets       | 
| License       | MIT
| Doc PR        | api-platform/docs#...