### PR TITLE
fix: enable the stateless firewall

### DIFF
--- a/api/config/packages/api_platform.yaml
+++ b/api/config/packages/api_platform.yaml
@@ -7,8 +7,9 @@ api_platform:
         json: ['application/merge-patch+json']
     swagger:
         versions: [3]
-    defaults:
-        stateless: true
     # Mercure integration, remove if unwanted
     mercure:
         hub_url: '%env(MERCURE_SUBSCRIBE_URL)%'
+    # Good defaults value for REST APIs
+    defaults:
+        stateless: true

--- a/api/config/packages/security.yaml
+++ b/api/config/packages/security.yaml
@@ -7,6 +7,7 @@ security:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         main:
+            stateless: true
             anonymous: true
             lazy: true
             provider: users_in_memory


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

The `stateless` attribute (https://github.com/api-platform/core/pull/3436) conflicts with a non-stateless firewall. Let's enable the `stateless` option of the firewall by default as it's a best practice for REST APIs. Also related: https://github.com/symfony/recipes/pull/853
