### PR TITLE
feat: allow more requests to be handled by the API

### DIFF
--- a/api/docker/caddy/Caddyfile
+++ b/api/docker/caddy/Caddyfile
@@ -10,10 +10,11 @@ log
     # Pass the request to the API for typical API media types.
     # `application/xml` is not in the list on purpose:
     # it is part of the default Accept header sent by browsers.
-    not header_regexp Accept (?i)(?:\bjson\b|text/(?:csv|xml)|application/x-yaml)
+    not header_regexp Accept (?i)(?:\bjson\b|^text/(?:csv|xml)$|^application/x-yaml$)
 
-    # Explicitly list routes always handled by the API.
-    not path /docs* /graphql* /bundles/* /_profiler* /_wdt*
+    # Explicitly list routes always handled by the API as well as
+    # URLs with an extension corresponding to common formats supported by the API.
+    not path_regexp (?i)(?:^/docs|^/graphql|^/bundles/|^/_profiler|^/_wdt|.+\.(?:json|html$|csv$|ya?ml$|xml$))
 }
 
 route {
@@ -34,6 +35,9 @@ route {
     }
     vulcain
     push
+    
+    # Comment the following line if you don't want Next.js to catch requests for HTML documents.
+    # In this case, they will be handled by the PHP app.
     reverse_proxy @pwa http://pwa:3000
     php_fastcgi php:9000
     encode gzip


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | yes <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Let the API handling more requests including `/my-resources.jsonld`, `/my-resources.html` (Swagger UI or Twig controller) etc.
Also tell how to disable Next.js to let Symfony handling all requests.