### PR TITLE
Update opcache.preload option to point to the correct file

### DIFF
--- a/api/docker/php/conf.d/api-platform.prod.ini
+++ b/api/docker/php/conf.d/api-platform.prod.ini
@@ -11,4 +11,4 @@ opcache.validate_timestamps = 0
 realpath_cache_size = 4096K
 realpath_cache_ttl = 600
 opcache.preload_user=www-data
-opcache.preload=/srv/api/var/cache/prod/App_KernelProdContainer.preload.php
+opcache.preload=/srv/api/config/preload.php


### PR DESCRIPTION
Fixed `opcache.preload`-option pointing to the wrong (and possibly non-existent) file

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | none

When starting up the PHP-Container for the first time when downloading the latest version of API-Platform (Cloned the GitHub Template of the current alpha-tag), an error occured

    Failed to open file /srv/api/var/cache/prod/App_KernelProdContainer.preload.php

I found the `preload.php` in the config, searched for it in the `api/` folder and realized it's not used, but it's loading exactly that file not found there, but only **if it exists** (since, it won't exist unless the platform is started in prod-env once)

I searched for `App_KernelProdContainer.preload.php` and replaced the file in the opcache config, I think the `config/preload.php` is the file that's supposed to be loaded when preloading.
