### PR TITLE
fix: remove satackey/action-docker-layer-caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
               uses: actions/checkout@v2
             - name: Pull images
               run: docker-compose pull
-            - uses: satackey/action-docker-layer-caching@v0.0.8
-              continue-on-error: true
             - name: Start services
               run: docker-compose up --build -d
             - name: Wait for services


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

I've the feeling that this action slows down the CI instead of making it faster... Let's compare.