### PR TITLE
Fix deprecated http_cache.vary

### DIFF
--- a/api/config/packages/api_platform.yaml
+++ b/api/config/packages/api_platform.yaml
@@ -7,12 +7,12 @@ api_platform:
         json: ['application/merge-patch+json']
     swagger:
         versions: [3]
-    # Good cache defaults
-    http_cache:
-        vary: ['Content-Type', 'Authorization', 'Origin']
     # Mercure integration, remove if unwanted
     mercure:
         hub_url: '%env(MERCURE_SUBSCRIBE_URL)%'
     # Good defaults value for REST APIs
     defaults:
         stateless: true
+        # Good cache defaults
+        cache_headers:
+            vary: ['Content-Type', 'Authorization', 'Origin']


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no (2.6)
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #... <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT
| Doc PR        | api-platform/docs#...

See @ https://github.com/api-platform/core/blob/master/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php#L370

Also, @dunglas I have a couple of questions:
- Mercure within Caddy doesn't have cors configuration and throws errors due to invalid configuration (should I add one within this template?).
- Mercure heartbeat default configuration doesn't poll every 40s to be compatible with event-source-polyfill library, adding heartbeat 30s to Caddy configuration fixes it.

Happy new year!
