### PR TITLE
Unable to bind listening socket for address '/var/run/php/php-fpm.sock

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -64,6 +64,8 @@ COPY docker/php/conf.d/api-platform.prod.ini $PHP_INI_DIR/conf.d/api-platform.in
 
 COPY docker/php/php-fpm.d/zz-docker.conf /usr/local/etc/php-fpm.d/zz-docker.conf
 
+VOLUME /var/run/php
+
 # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
 ENV COMPOSER_ALLOW_SUPERUSER=1
 ENV PATH="${PATH}:/root/.composer/vendor/bin"


### PR DESCRIPTION
```
api_platform\api> docker build --target api_platform_php -t php-api .
docker run --rm -it --entrypoint=sh php-api

/srv/api # ls /var/run/
/srv/api # php-fpm
[19-Jan-2021 07:59:48] ERROR: unable to bind listening socket for address '/var/run/php/php-fpm.sock': No such file or directory (2)
[19-Jan-2021 07:59:48] ERROR: FPM initialization failed

```

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes<!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #1766
| License       | MIT

https://www.nginx.com/resources/wiki/start/topics/examples/phpfcgi/#connecting-nginx-to-php-fpm
```
If you’re using unix socket change fastcgi_pass to:

fastcgi_pass unix:/var/run/php-fpm.sock;
```
