### PR TITLE
Fix enableBackground not assignable to type CSSProperties

### DIFF
--- a/pwa/pages/index.tsx
+++ b/pwa/pages/index.tsx
@@ -2671,7 +2671,6 @@ const Sto = () => (
         width={25}
         height={25}
         viewBox="0 0 120 120"
-        enableBackground="new 0 0 120 120"
     >
         <style jsx>
             {`

--- a/pwa/pages/index.tsx
+++ b/pwa/pages/index.tsx
@@ -2671,7 +2671,7 @@ const Sto = () => (
         width={25}
         height={25}
         viewBox="0 0 120 120"
-        style={{ enableBackground: "new 0 0 120 120" }}
+        enableBackground="new 0 0 120 120"
     >
         <style jsx>
             {`


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

```sh
Failed to compile.

./pages/index.tsx:2674:18
Type error: Type '{ enableBackground: string; }' is not assignable to type 'CSSProperties'.
  Object literal may only specify known properties, and 'enableBackground' does not exist in type 'CSSProperties'.

  2672 |         height={25}
  2673 |         viewBox="0 0 120 120"
> 2674 |         style={{ enableBackground: "new 0 0 120 120" }}
       |                  ^
  2675 |     >
  2676 |         <style jsx>
  2677 |             {`
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
enableBackground is an SVGAttribute rather than a CSSProperty.
It's also deprecated: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/enable-background

The Slack Icon and other SVG's don't have the enableBackground SVGAttribute.
https://stackoverflow.com/questions/21354116/what-exactly-does-the-enable-background-attribute-do
As far as browser support I think it's only for IE11/legacy Edge(non Chromium).

I can't find any added value to the SVG. I can remove it. What do you think @dunglas ?