### PR TITLE
Remove REACT_APP_API_ENTRYPOINT

### DIFF
--- a/pwa/.env
+++ b/pwa/.env
@@ -1,1 +1,0 @@
-REACT_APP_API_ENTRYPOINT=https://localhost

--- a/pwa/Dockerfile
+++ b/pwa/Dockerfile
@@ -38,7 +38,6 @@ CMD ["yarn", "dev"]
 FROM api_platform_pwa_common AS api_platform_pwa_prod
 
 ENV NODE_ENV production
-ARG REACT_APP_API_ENTRYPOINT
 
 RUN set -eux; \
 	yarn build

--- a/pwa/pages/admin/index.tsx
+++ b/pwa/pages/admin/index.tsx
@@ -3,7 +3,7 @@ import Head from "next/head";
 const AdminLoader = () => {
   if (typeof window !== "undefined") {
     const { HydraAdmin } = require("@api-platform/admin");
-    return <HydraAdmin entrypoint="/" />;
+    return <HydraAdmin entrypoint={window.origin} />;
   }
 
   return <></>;

--- a/pwa/pages/admin/index.tsx
+++ b/pwa/pages/admin/index.tsx
@@ -1,12 +1,9 @@
 import Head from "next/head";
 
-const API_ENTRYPOINT =
-  process.env.REACT_APP_API_ENTRYPOINT || "https://localhost";
-
 const AdminLoader = () => {
   if (typeof window !== "undefined") {
     const { HydraAdmin } = require("@api-platform/admin");
-    return <HydraAdmin entrypoint={API_ENTRYPOINT} />;
+    return <HydraAdmin entrypoint="/" />;
   }
 
   return <></>;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | no <!-- please update CHANGELOG.md file -->
| New feature?  | no <!-- please update CHANGELOG.md file -->
| Deprecations? | no
| Tickets       | Fix #1844
| License       | MIT
| Doc PR        | todo

This environment variable isn't necessary anymore.