### PR TITLE
fix: use gnu-libiconv package

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -19,6 +19,9 @@ RUN apk add --no-cache \
 		git \
 		gnu-libiconv \
 	;
+
+# install gnu-libiconv and set LD_PRELOAD env to make iconv work fully on Alpine image.
+# see https://github.com/docker-library/php/issues/240#issuecomment-763112749
 ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so
 
 ARG APCU_VERSION=5.1.19

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -17,7 +17,9 @@ RUN apk add --no-cache \
 		file \
 		gettext \
 		git \
+		gnu-libiconv \
 	;
+ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so
 
 ARG APCU_VERSION=5.1.19
 RUN set -eux; \


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #1532
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

Theres an issue with `iconv` in the `alpine` `php` distribution, resulting in errors like 
```
php Notice: iconv(): Wrong charset, conversion from UTF-8' to ASCII//TRANSLIT' is not allowed
```

If you use the `gnu-libiconv` package and change the `LD_PRELOAD` env var it works. There's no need to add any "unstable" repositories anymore. Tested with `php:8.0.3-fpm-alpine`.

From https://github.com/docker-library/php/issues/240#issuecomment-763112749

