### PR TITLE
fix: disable Google FLoC tracking by default

### DIFF
--- a/api/docker/caddy/Caddyfile
+++ b/api/docker/caddy/Caddyfile
@@ -44,8 +44,12 @@ route {
     vulcain
     push
 
-    # Add links to the API docs and to the Mercure Hub if not set explicitly (e.g. the PWA)
-    header ?Link `</docs.jsonld>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation", </.well-known/mercure>; rel="mercure"`
+    header {
+        # Add links to the API docs and to the Mercure Hub if not set explicitly (e.g. the PWA)
+        ?Link `</docs.jsonld>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation", </.well-known/mercure>; rel="mercure"`
+        # Disable Google FLOC tracking if not enabled explicitly: https://plausible.io/blog/google-floc
+        ?Permissions-Policy "interest-cohort=()"
+    }
 
     # Comment the following line if you don't want Next.js to catch requests for HTML documents.
     # In this case, they will be handled by the PHP app.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | yes <!-- please update CHANGELOG.md file -->
| New feature?  | no <!-- please update CHANGELOG.md file -->
| Deprecations? | no
| Tickets       | Related to https://github.com/symfony/symfony/issues/40835
| License       | MIT
| Doc PR        | n/a

Google’s Federated Learning of Cohorts is a new initiative to track internet users without their consent. This feature is already enabled by default for a small percentage of Google Chrome users, and is intended to be enabled for all users at the end of the experiment.
Developers can opt their websites out of FLoC by setting this HTTP header: `Permissions-Policy: interest-cohort=()`.

This PR sets this header by default in the API Platform distribution.
 
For more information about FLoC read [Google’s FLoC Is a Terrible Idea](https://www.eff.org/deeplinks/2021/03/googles-floc-terrible-idea) by @EFForg and [How to fight back against Google FLoC](https://plausible.io/blog/google-floc) by @plausible.