### PR TITLE
fix: ensure that the latest version of Mercure and Vulcain are always used

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -121,7 +121,9 @@ CMD ["php-fpm"]
 FROM caddy:${CADDY_VERSION}-builder-alpine AS api_platform_caddy_builder
 
 RUN xcaddy build \
+    --with github.com/dunglas/mercure \
     --with github.com/dunglas/mercure/caddy \
+    #--with github.com/dunglas/vulcain \
     --with github.com/dunglas/vulcain/caddy
 
 FROM caddy:${CADDY_VERSION} AS api_platform_caddy

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -122,9 +122,9 @@ FROM caddy:${CADDY_VERSION}-builder-alpine AS api_platform_caddy_builder
 
 RUN xcaddy build \
     --with github.com/dunglas/mercure \
-    --with github.com/dunglas/mercure/caddy \
+    --with github.com/dunglas/mercure/caddy
     #--with github.com/dunglas/vulcain \
-    --with github.com/dunglas/vulcain/caddy
+    #--with github.com/dunglas/vulcain/caddy
 
 FROM caddy:${CADDY_VERSION} AS api_platform_caddy
 

--- a/api/docker/caddy/Caddyfile
+++ b/api/docker/caddy/Caddyfile
@@ -41,7 +41,7 @@ route {
         # Extra directives
         {$MERCURE_EXTRA_DIRECTIVES}
     }
-    vulcain
+    #vulcain
     push
 
     header {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | yes <!-- please update CHANGELOG.md file -->
| New feature?  | no <!-- please update CHANGELOG.md file -->
| Deprecations? | no
| Tickets       | Close https://github.com/api-platform/api-platform/issues/1881
| License       | MIT
| Doc PR        | n/a

See https://github.com/dunglas/mercure/pull/499.