### PR TITLE
fix: header defaults in Caddyfile must be in separate handlers

### DIFF
--- a/api/docker/caddy/Caddyfile
+++ b/api/docker/caddy/Caddyfile
@@ -44,12 +44,10 @@ route {
     vulcain
     push
 
-    header {
-        # Add links to the API docs and to the Mercure Hub if not set explicitly (e.g. the PWA)
-        ?Link `</docs.jsonld>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation", </.well-known/mercure>; rel="mercure"`
-        # Disable Google FLOC tracking if not enabled explicitly: https://plausible.io/blog/google-floc
-        ?Permissions-Policy "interest-cohort=()"
-    }
+    # Add links to the API docs and to the Mercure Hub if not set explicitly (e.g. the PWA)
+    header ?Link `</docs.jsonld>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation", </.well-known/mercure>; rel="mercure"`
+    # Disable Google FLOC tracking if not enabled explicitly: https://plausible.io/blog/google-floc
+    header ?Permissions-Policy "interest-cohort=()"
 
     # Comment the following line if you don't want Next.js to catch requests for HTML documents.
     # In this case, they will be handled by the PHP app.


### PR DESCRIPTION
Discussion in https://github.com/caddyserver/caddy/issues/4130 brought this up.

There's a bit of a gotcha here, in that having two `?Field` headers will append each to the `Require` response matcher, so those header fields will only be set if _both_ are not present in the response. If one is present (e.g. `Link` is in the response) then neither are set.

Using separate header handlers solves this because they will use their own handlers, and therefore separate response matchers.

This is just a followup to https://github.com/api-platform/api-platform/pull/1879 to fix this non-obvious behaviour.

| Q             | A
| ------------- | ---
| Branch?       | main <!-- see below -->
| Bug fix?      | yes <!-- please update CHANGELOG.md file -->
| New feature?  | no <!-- please update CHANGELOG.md file -->
| Deprecations? | no
| Tickets       | N/A <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | N/A <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
-->
