### PR TITLE
Fix: upgrade dockerfile PHP version to 8.0.7

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,7 +4,7 @@
 
 
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
-ARG PHP_VERSION=8.0
+ARG PHP_VERSION=8.0.7
 ARG CADDY_VERSION=2
 
 # "php" stage


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | ~
| License       | MIT
| Doc PR        | N/A

Docker hub PHP@8.0 downloads the 8.0.0 version
but the 8.0.2 is required by the composer.json file
