### PR TITLE
fix: export ENTRYPOINT in pwa/config/entrypoint.ts

### DIFF
--- a/pwa/config/entrypoint.ts
+++ b/pwa/config/entrypoint.ts
@@ -1,1 +1,1 @@
-export const NEXT_PUBLIC_ENTRYPOINT = typeof window === "undefined" ? process.env.NEXT_PUBLIC_ENTRYPOINT : window.origin;
+export const ENTRYPOINT = typeof window === "undefined" ? process.env.NEXT_PUBLIC_ENTRYPOINT : window.origin;


### PR DESCRIPTION
The `dataAccess` module imports the `ENTRYPOINT` const, and not `NEXT_PUBLIC_ENTRYPOINT`:
https://github.com/api-platform/client-generator/blob/cf9663004bb839965c49b4db2de6d18bea696f74/templates/next/utils/dataAccess.ts#L5