### PR TITLE
feat: add varnish WIP

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -6,6 +6,8 @@
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG PHP_VERSION=8.0
 ARG CADDY_VERSION=2
+ARG VARNISH_VERSION=6.6
+#ARG VARNISH_VERSION="stable"
 
 # "php" stage
 FROM php:${PHP_VERSION}-fpm-alpine AS api_platform_php
@@ -134,3 +136,18 @@ COPY --from=dunglas/mercure:v0.11 /srv/public /srv/mercure-assets/
 COPY --from=api_platform_caddy_builder /usr/bin/caddy /usr/bin/caddy
 COPY --from=api_platform_php /srv/api/public public/
 COPY docker/caddy/Caddyfile /etc/caddy/Caddyfile
+
+
+
+# "varnish" stage
+# does not depend on any of the above stages, but placed here to keep everything in one Dockerfile
+
+# This one is preferred for default APIP
+#FROM varnish:${VARNISH_VERSION} AS api_platform_varnish
+# only temp for develop on Mac M1 - ARM64 not available for org. varnish
+FROM beevelop/varnish AS api_platform_varnish
+
+COPY docker/varnish/conf/default.vcl /etc/varnish/default.vcl
+COPY docker/varnish/conf/default.vcl varnish.vcl
+
+CMD ["varnishd", "-F", "-f", "/etc/varnish/default.vcl", "-p", "http_resp_hdr_len=65536", "-p", "http_resp_size=98304"]

--- a/api/config/packages/api_platform.yaml
+++ b/api/config/packages/api_platform.yaml
@@ -9,6 +9,21 @@ api_platform:
         versions: [3]
     # Mercure integration, remove if unwanted
     mercure: ~
+
+    http_cache:
+        # To make all responses public by default.
+        public: ~
+
+        invalidation:
+            # To enable the tags-based cache invalidation system.
+            enabled: true
+
+            # URLs of the Varnish servers to purge using cache tags when a resource is updated.
+            varnish_urls: ['varnish:80']
+
+            # To pass options to the client charged with the request.
+            #request_options: [ ]
+                
     # Good cache defaults for REST APIs
     defaults:
         stateless: true

--- a/api/docker/caddy/Caddyfile
+++ b/api/docker/caddy/Caddyfile
@@ -1,4 +1,6 @@
 {
+    auto_https disable_redirects
+
     # Debug
     {$DEBUG}
     # HTTP/3 support
@@ -9,7 +11,16 @@
     }
 }
 
-{$SERVER_NAME}
+
+localhost:443, localhost:80  {
+        log
+        reverse_proxy varnish:80
+}
+
+#{$SERVER_NAME}
+
+:2368
+{
 
 log
 
@@ -51,9 +62,11 @@ route {
 
     # Comment the following line if you don't want Next.js to catch requests for HTML documents.
     # In this case, they will be handled by the PHP app.
-    reverse_proxy @pwa http://{$PWA_UPSTREAM}
+    #reverse_proxy @pwa http://{$PWA_UPSTREAM}
 
     php_fastcgi unix//var/run/php/php-fpm.sock
     encode zstd gzip
     file_server
+}
+
 }

--- a/api/docker/varnish/conf/default.vcl
+++ b/api/docker/varnish/conf/default.vcl
@@ -1,0 +1,97 @@
+vcl 4.0;
+
+import std;
+
+backend default {
+  .host = "caddy";
+  .port = "2368";
+  # Health check
+  #.probe = {
+  #  .url = "/";
+  #  .timeout = 5s;
+  #  .interval = 10s;
+  #  .window = 5;
+  #  .threshold = 3;
+  #}
+}
+
+
+# Hosts allowed to send BAN requests
+acl invalidators {
+  "localhost";
+  "caddy";
+  "php";
+  # local Kubernetes network
+  "10.0.0.0"/8;
+  "172.16.0.0"/12;
+  "192.168.0.0"/16;
+}
+
+sub vcl_recv {
+  if (req.restarts > 0) {
+    set req.hash_always_miss = true;
+  }
+
+  # Remove the "Forwarded" HTTP header if exists (security)
+  unset req.http.forwarded;
+
+  # To allow API Platform to ban by cache tags
+  if (req.method == "BAN") {
+    if (client.ip !~ invalidators) {
+      return (synth(405, "Not allowed"));
+    }
+
+    if (req.http.ApiPlatform-Ban-Regex) {
+      ban("obj.http.Cache-Tags ~ " + req.http.ApiPlatform-Ban-Regex);
+
+      return (synth(200, "Ban added"));
+    }
+
+    return (synth(400, "ApiPlatform-Ban-Regex HTTP header must be set."));
+  }
+
+  # For health checks
+  if (req.method == "GET" && req.url == "/healthz") {
+    return (synth(200, "OK"));
+  }
+}
+
+sub vcl_hit {
+  if (obj.ttl >= 0s) {
+    # A pure unadulterated hit, deliver it
+    return (deliver);
+  }
+
+  if (std.healthy(req.backend_hint)) {
+    # The backend is healthy
+    # Fetch the object from the backend
+    return (restart);
+  }
+
+  # No fresh object and the backend is not healthy
+  if (obj.ttl + obj.grace > 0s) {
+    # Deliver graced object
+    # Automatically triggers a background fetch
+    return (deliver);
+  }
+
+  # No valid object to deliver
+  # No healthy backend to handle request
+  # Return error
+  return (synth(503, "API is down"));
+}
+
+sub vcl_deliver {
+  # Don't send cache tags related headers to the client
+  unset resp.http.url;
+  # Comment the following line to send the "Cache-Tags" header to the client (e.g. to use CloudFlare cache tags)
+  unset resp.http.Cache-Tags;
+}
+
+sub vcl_backend_response {
+  # Ban lurker friendly header
+  set beresp.http.url = bereq.url;
+
+  # Add a grace in case the backend is down
+  set beresp.grace = 1h;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,16 @@ services:
         published: 443
         protocol: udp
 
+  varnish:
+    build:
+      context: api/
+      target: api_platform_varnish
+    depends_on: 
+      - caddy
+    environment:
+      BACKEND_PORT: 6081
+    restart: unless-stopped
+
   database:
     image: postgres:13-alpine
     environment:


### PR DESCRIPTION
This is just a proof of concept for varnish with APIP 2.6.
It is **buggy**. /docs need sometimes refreshed 4-6 times to work.
PWA, Vulcain, Mercure is not supported (or tested) at the moment.
I try to reuse varnish code from apip 2.5.

You may want to change these lines for your platform in /api/Dockerfile
#FROM varnish:${VARNISH_VERSION} AS api_platform_varnish
# only temp for develop on Mac M1 - ARM64 not available for org. varnish
FROM beevelop/varnish AS api_platform_varnish

I am working on the deployment for kubernetes. Varnish is called but could not cache invalidation working.
Until this is fixed i am not gone push that.
