### PR TITLE
fix: set php-fpm process_control_timeout

### DIFF
--- a/api/docker/php/php-fpm.d/zz-docker.conf
+++ b/api/docker/php/php-fpm.d/zz-docker.conf
@@ -1,5 +1,6 @@
 [global]
 daemonize = no
+process_control_timeout = 20
 
 [www]
 listen = /var/run/php/php-fpm.sock


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

In the [helm chart](https://github.com/api-platform/api-platform/blob/main/helm/api-platform/templates/deployment.yaml#L139) its defined that when the pod is stopped, the `"/bin/sh", "-c", "/bin/sleep 1; kill -QUIT 1"` commands are executed. I was quite curious who came up with that and why, and ended up reading [this](https://medium.com/flant-com/kubernetes-graceful-shutdown-nginx-php-fpm-d5ab266963c2) article. This was the only resource I could find explaining this exact command.

It perfectly explains the reason for this command, however it also states that it should be combined with the `process_control_timeout` directive. This PR adds the directive to the php-fpm config.

@vincentchalamon as you are the one who added the `preStop` hook in your [PR](https://github.com/api-platform/api-platform/commit/18b167da5fe136930eeb16f9f8bfa95881a6dbce#diff-12fc8db2fcd60cf94d696956722fbf000d1195e06b596d5c2740b37a7f0956a1R136), do you agree?