### PR TITLE
fix: replicaCount value in helm chart

### DIFF
--- a/helm/api-platform/values.yaml
+++ b/helm/api-platform/values.yaml
@@ -8,7 +8,6 @@ php:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
-  replicaCount: 1
   appEnv: prod
   appDebug: "0"
   appSecret: ""
@@ -33,8 +32,6 @@ caddy:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
-  # If you use Mercure, you need the managed or the On Premise version to deploy more than one pod: https://mercure.rocks/docs/hub/cluster
-  replicaCount: 1
 
 # You may prefer using the managed version in production: https://mercure.rocks
 mercure:
@@ -114,6 +111,9 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+
+# If you use Mercure, you need the managed or the On Premise version to deploy more than one pod: https://mercure.rocks/docs/hub/cluster
+replicaCount: 1
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | #2003
| License       | MIT
| Doc PR        | 

replicaCount always used the default value of 1 because of https://github.com/api-platform/api-platform/blob/7d8eb360592583a7b7ca76708c64c6d495e26383/helm/api-platform/templates/deployment.yaml#L9
