### PR TITLE
Do not create VOLUME for node_modules inside pwa/Dockerfile

### DIFF
--- a/pwa/Dockerfile
+++ b/pwa/Dockerfile
@@ -20,8 +20,6 @@ RUN yarn
 
 COPY . ./
 
-VOLUME /usr/src/pwa/node_modules
-
 
 # "development" stage
 # depends on the "common" stage above


### PR DESCRIPTION
It was added here without any explanation https://github.com/api-platform/api-platform/pull/1228 by @teohhanhui (if you have any comments - that would be very helpful)

Notes:

* Inside `api/Dockerfile` - there is no `VOLUME` for `vendor` folder, so it's not clear why we use `VOLUME` for JS application
* Because of this `VOLUME`, node modules folder is populated only inside docker volume, but **not on the host machine** during development. This required developers to run `yarn install` locally in order to have `node_modules` populated for IDE inspections

After this update, `node_modules` will work the same way as `vendor` folder works inside `api` app, so it will be shared thanks to docker bind-mount from `docker-compose.override.yaml`:

https://github.com/api-platform/api-platform/blob/0c19b09a05c268b4326b1cf9e32fcef5c4e238fc/docker-compose.override.yml#L19

I've targeted `main` branch because it may affect developer's workflow.

To start using this approach, I had to remove volume locally and rebuild the image:

* `docker-compose down -v` (too aggressive but ok in my case)
* `docker-compose build --no-cache --force-rm client`