### PR TITLE
feat: Set `APP_DEBUG` to `false` in `phpunit.xml` to speed up the tests

### DIFF
--- a/api/phpunit.xml.dist
+++ b/api/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <ini name="display_errors" value="1" />
         <ini name="error_reporting" value="-1" />
         <server name="APP_ENV" value="test" force="true" />
+        <server name="APP_DEBUG" value="false" />
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
         <server name="SYMFONY_PHPUNIT_VERSION" value="9.5" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main 
| Tickets       | -
| License       | MIT
| Doc PR        | -

It was proposed [back in 2019](https://github.com/symfony/recipes/pull/530) by `@javiereguiluz`, but for some reason didn't get enough popularity. Though, now Symfony's documentation mentions this improvement in a ["Set-up your Test Environment"](https://symfony.com/doc/current/testing.html#set-up-your-test-environment) paragraph:

> It is recommended to run your test with `debug` set to `false` on your CI server, as it significantly improves test performance.

Disabling `debug` mode also disables clearing the cache. And if your tests don't run in a clean environment each time (for example tests are executed locally, where you always change the source files), you have to manually clear the cache each time `PHPUnit` is executed. 

This is how it looks like on our project inside `PHPUnit`'s `bootstrap` file:

```php
<?php

use Symfony\Component\Filesystem\Filesystem;

require dirname(__DIR__).'/vendor/autoload.php';

// ...

(new Filesystem())->remove([__DIR__ . '/../var/cache/test']);

echo "\nTest cache cleared\n";
```

We can live with this "inconvenience", especially with the benefit it gets.

```diff
- Time: 04:13.959, Memory: 547.01 MB
+ Time: 02:45.307, Memory: 473.00 MB
```

---

Back in 2019, @teohhanhui [was agree](https://github.com/symfony/recipes/pull/530#issuecomment-554495243) that this is a good and valueable change.

This is only one of the many optimizations of the tests suite available for the end developer. Other ones are listed in my blog post: https://maks-rafalko.github.io/blog/2021-11-21/symfony-tests-performance/.

Related to the first improvement about Password Hashers: https://github.com/api-platform/docs/pull/1472

Things to do:

- [ ] Discuss and agree with the approach
- [ ] If agreed by maintainers, update `tests/bootstrap` to remove the `var/cache/test` before running PHPUnit
