### PR TITLE
Feature: optionally use mysql (but keep postgres as the default)

### DIFF
--- a/.env
+++ b/.env
@@ -1,15 +1,17 @@
 # Postgres
 DATABASE_ENGINE=postgresql
-DATABASE_URL=${DATABASE_ENGINE}://${POSTGRES_USER:-api-platform}:${POSTGRES_PASSWORD:-!ChangeMe!}@database:5432/${POSTGRES_DB:-api}?serverVersion=${POSTGRES_VERSION:-13}
+# DATABASE_URL=${DATABASE_ENGINE:postgresql}://${POSTGRES_USER:api-platform}:${POSTGRES_PASSWORD:!ChangeMe!}@database:5432/${POSTGRES_DB:api}?serverVersion=13
+DATABASE_URL=postgresql://api-platform:!ChangeMe!@database:5432/api?serverVersion=13
 ## Dev environment
-COMPOSE_FILE=docker-compose.yml:docker-compose.override.yml:docker-compose.override.postgres.yml:docker-compose.postgres.yml
+COMPOSE_FILE=docker-compose.yml:docker-compose.postgres.yml:docker-compose.override.yml:docker-compose.override.postgres.yml
 ## Production environment
 # COMPOSE_FILE=docker-compose.yml:docker-compose.prod.yml:docker-compose.postgres.yml
 
 # mysql
-DATABASE_ENGINE=mysql
-DATABASE_URL=${DATABASE_ENGINE}://${MYSQL_USER:-api-platform}:${MYSQL_PASSWORD:-!ChangeMe!}@${MYSQL_HOST:-database}:${MYSQL_PORT:-3306}/${MYSQL_DATABASE:-api}?serverVersion=${MYSQL_VERSION:-8}
+# DATABASE_ENGINE=mysql
+# DATABASE_URL=${DATABASE_ENGINE:mysql}://${MYSQL_USER:api-platform}:${MYSQL_PASSWORD:!ChangeMe!}@${MYSQL_HOST:database}:${MYSQL_PORT:3306}/${MYSQL_DATABASE:api}?serverVersion=${MYSQL_VERSION:8}
+# DATABASE_URL=mysql://api-platform:!ChangeMe!@database:3306/api?serverVersion=8
 ## Dev environment
-#COMPOSE_FILE=docker-compose.yml:docker-compose.override.yml:docker-compose.mysql.yml
+# COMPOSE_FILE=docker-compose.yml:docker-compose.override.yml:docker-compose.mysql.yml
 ## Production environment
 # COMPOSE_FILE=docker-compose.yml:docker-compose.prod.yml:docker-compose.mysql.yml

--- a/.env
+++ b/.env
@@ -1,17 +1,15 @@
+# Only works with docker-compose up. See https://docs.docker.com/compose/environment-variables/
+
 # Postgres
 DATABASE_ENGINE=postgresql
-# DATABASE_URL=${DATABASE_ENGINE:postgresql}://${POSTGRES_USER:api-platform}:${POSTGRES_PASSWORD:!ChangeMe!}@database:5432/${POSTGRES_DB:api}?serverVersion=13
-DATABASE_URL=postgresql://api-platform:!ChangeMe!@database:5432/api?serverVersion=13
 ## Dev environment
 COMPOSE_FILE=docker-compose.yml:docker-compose.postgres.yml:docker-compose.override.yml:docker-compose.override.postgres.yml
 ## Production environment
-# COMPOSE_FILE=docker-compose.yml:docker-compose.prod.yml:docker-compose.postgres.yml
+# COMPOSE_FILE=docker-compose.yml:docker-compose.postgres.yml:docker-compose.prod.yml
 
 # mysql
 # DATABASE_ENGINE=mysql
-# DATABASE_URL=${DATABASE_ENGINE:mysql}://${MYSQL_USER:api-platform}:${MYSQL_PASSWORD:!ChangeMe!}@${MYSQL_HOST:database}:${MYSQL_PORT:3306}/${MYSQL_DATABASE:api}?serverVersion=${MYSQL_VERSION:8}
-# DATABASE_URL=mysql://api-platform:!ChangeMe!@database:3306/api?serverVersion=8
 ## Dev environment
-# COMPOSE_FILE=docker-compose.yml:docker-compose.override.yml:docker-compose.mysql.yml
+# COMPOSE_FILE=docker-compose.yml:docker-compose.mysql.yml:docker-compose.override.yml
 ## Production environment
-# COMPOSE_FILE=docker-compose.yml:docker-compose.prod.yml:docker-compose.mysql.yml
+# COMPOSE_FILE=docker-compose.yml:docker-compose.mysql.yml:docker-compose.prod.yml

--- a/.env
+++ b/.env
@@ -1,0 +1,15 @@
+# Postgres
+DATABASE_ENGINE=postgresql
+DATABASE_URL=${DATABASE_ENGINE}://${POSTGRES_USER:-api-platform}:${POSTGRES_PASSWORD:-!ChangeMe!}@database:5432/${POSTGRES_DB:-api}?serverVersion=${POSTGRES_VERSION:-13}
+## Dev environment
+COMPOSE_FILE=docker-compose.yml:docker-compose.override.yml:docker-compose.override.postgres.yml:docker-compose.postgres.yml
+## Production environment
+# COMPOSE_FILE=docker-compose.yml:docker-compose.prod.yml:docker-compose.postgres.yml
+
+# mysql
+DATABASE_ENGINE=mysql
+DATABASE_URL=${DATABASE_ENGINE}://${MYSQL_USER:-api-platform}:${MYSQL_PASSWORD:-!ChangeMe!}@${MYSQL_HOST:-database}:${MYSQL_PORT:-3306}/${MYSQL_DATABASE:-api}?serverVersion=${MYSQL_VERSION:-8}
+## Dev environment
+#COMPOSE_FILE=docker-compose.yml:docker-compose.override.yml:docker-compose.mysql.yml
+## Production environment
+# COMPOSE_FILE=docker-compose.yml:docker-compose.prod.yml:docker-compose.mysql.yml

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -62,7 +62,7 @@ RUN set -eux; \
 ARG DATABASE_ENGINE=postgresql
 
 RUN if [ "$DATABASE_ENGINE" = "postgresql" ] ; then \
-    apk add --no-cache --virtual .pgsql-deps postgresql-dev; \
+	apk add --no-cache --virtual .pgsql-deps postgresql-dev; \
 	docker-php-ext-install -j$(nproc) pdo_pgsql; \
 	apk add --no-cache --virtual .pgsql-rundeps so:libpq.so.5; \
 	apk del .pgsql-deps ; \
@@ -70,7 +70,7 @@ RUN if [ "$DATABASE_ENGINE" = "postgresql" ] ; then \
 
 RUN if [ "$DATABASE_ENGINE" = "mysql" ] ; then \
 	docker-php-ext-install -j$(nproc) mysqli pdo pdo_mysql; \
-    docker-php-ext-enable mysqli ; \
+	docker-php-ext-enable mysqli ; \
 	fi
 ###< doctrine/doctrine-bundle ###
 ###< recipes ###

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -6,8 +6,6 @@
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG PHP_VERSION=8.1
 ARG CADDY_VERSION=2
-ARG DATABASE_ENGINE=postgresql
-# ARG DATABASE_ENGINE=mysql
 
 # "php" stage
 FROM php:${PHP_VERSION}-fpm-alpine AS api_platform_php
@@ -61,6 +59,8 @@ RUN set -eux; \
 
 ###> recipes ###
 ###> doctrine/doctrine-bundle ###
+ARG DATABASE_ENGINE=postgresql
+
 RUN if [ "$DATABASE_ENGINE" = "postgresql" ] ; then \
     apk add --no-cache --virtual .pgsql-deps postgresql-dev; \
 	docker-php-ext-install -j$(nproc) pdo_pgsql; \

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -59,10 +59,17 @@ RUN set -eux; \
 
 ###> recipes ###
 ###> doctrine/doctrine-bundle ###
-RUN apk add --no-cache --virtual .pgsql-deps postgresql-dev; \
+RUN if [ "$DATABASE_ENGINE" = "postgresql" ] ; then \
+    apk add --no-cache --virtual .pgsql-deps postgresql-dev; \
 	docker-php-ext-install -j$(nproc) pdo_pgsql; \
 	apk add --no-cache --virtual .pgsql-rundeps so:libpq.so.5; \
-	apk del .pgsql-deps
+	apk del .pgsql-deps ; \
+	fi
+
+RUN if [ "$DATABASE_ENGINE" = "postgresql" ] ; then \
+	docker-php-ext-install -j$(nproc) mysqli pdo pdo_mysql; \
+    docker-php-ext-enable mysqli ; \
+	fi
 ###< doctrine/doctrine-bundle ###
 ###< recipes ###
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -6,6 +6,8 @@
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG PHP_VERSION=8.1
 ARG CADDY_VERSION=2
+ARG DATABASE_ENGINE=postgresql
+# ARG DATABASE_ENGINE=mysql
 
 # "php" stage
 FROM php:${PHP_VERSION}-fpm-alpine AS api_platform_php
@@ -66,7 +68,7 @@ RUN if [ "$DATABASE_ENGINE" = "postgresql" ] ; then \
 	apk del .pgsql-deps ; \
 	fi
 
-RUN if [ "$DATABASE_ENGINE" = "postgresql" ] ; then \
+RUN if [ "$DATABASE_ENGINE" = "mysql" ] ; then \
 	docker-php-ext-install -j$(nproc) mysqli pdo pdo_mysql; \
     docker-php-ext-enable mysqli ; \
 	fi

--- a/api/migrations/Version20210930074739.php
+++ b/api/migrations/Version20210930074739.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
@@ -19,16 +21,24 @@ final class Version20210930074739 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
-        $this->addSql('CREATE SEQUENCE greeting_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
-        $this->addSql('CREATE TABLE greeting (id INT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id))');
+        $platform = $this->connection->getDatabasePlatform();
+        if ($platform instanceof MySQLPlatform) {
+            $this->addSql('CREATE TABLE greeting (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        } else if ($platform instanceof PostgreSQLPlatform) {
+            $this->addSql('CREATE SEQUENCE greeting_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
+            $this->addSql('CREATE TABLE greeting (id INT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id))');
+        }
+
     }
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
-        $this->addSql('CREATE SCHEMA public');
-        $this->addSql('DROP SEQUENCE greeting_id_seq CASCADE');
-        $this->addSql('DROP TABLE greeting');
+        $platform = $this->connection->getDatabasePlatform();
+        if ($platform instanceof MySQLPlatform) {
+            $this->addSql('DROP TABLE greeting');
+        }  else if ($platform instanceof PostgreSQLPlatform) {
+            $this->addSql('CREATE SCHEMA public');
+            $this->addSql('DROP SEQUENCE greeting_id_seq CASCADE');
+        }
     }
 }

--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -6,7 +6,7 @@ services:
     depends_on:
       - database
     environment:
-      DATABASE_URL: mysql://${MYSQL_USER}:${MYSQL_PASSWORD}@${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}?serverVersion=${MYSQL_VERSION}
+      DATABASE_URL: mysql://${MYSQL_USER:-api-platform}:${MYSQL_PASSWORD:-!ChangeMe!}@${MYSQL_HOST:-127.0.0.1}:${MYSQL_PORT:-3306}/${MYSQL_DATABASE:-api}?serverVersion=${MYSQL_VERSION:-8}
 
 ###> doctrine/doctrine-bundle ###
   database:
@@ -16,9 +16,9 @@ services:
           condition: on-failure
       environment:
         MYSQL_ROOT_PASSWORD: ${DATABASE_ROOT_PASSWORD}
-        MYSQL_DATABASE: ${MYSQL_DATABASE}
-        MYSQL_USER: ${MYSQL_USER}
-        MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+        MYSQL_DATABASE: ${MYSQL_DATABASE:-api}
+        MYSQL_USER: ${MYSQL_USER:-api-platform}
+        MYSQL_PASSWORD: ${MYSQL_PASSWORD:-!ChangeMe!}
       volumes:
         - db_data:/var/lib/mysql:rw
       ports:

--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -6,7 +6,7 @@ services:
     depends_on:
       - database
     environment:
-      DATABASE_URL: mysql://${MYSQL_USER:-api-platform}:${MYSQL_PASSWORD:-!ChangeMe!}@database:${MYSQL_PORT:-3306}/${MYSQL_DATABASE:-api}?serverVersion=${MYSQL_VERSION:-8}
+      DATABASE_URL: mysql://${MYSQL_USER:-api-platform}:${MYSQL_PASSWORD:-!ChangeMe!}@database:3306/${MYSQL_DATABASE:-api}?serverVersion=${MYSQL_VERSION:-8}
 
 ###> doctrine/doctrine-bundle ###
   database:

--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -1,0 +1,30 @@
+version: "3.4"
+
+# To run mysql as part of Docker
+services:
+  php:
+    depends_on:
+      - database
+
+###> doctrine/doctrine-bundle ###
+  database:
+      image: mysql:8
+      deploy:
+        restart_policy:
+          condition: on-failure
+      environment:
+        - MYSQL_ROOT_PASSWORD=${DATABASE_ROOT_PASSWORD}
+        - MYSQL_DATABASE=${DATABASE_NAME}
+        - MYSQL_USER=${DATABASE_USER}
+        - MYSQL_PASSWORD=${DATABASE_PASSWORD}
+      volumes:
+        # is this correct?
+        - db_data:/var/lib/mysql:rw
+      ports:
+        - 3306:3306
+###< doctrine/doctrine-bundle ###
+
+volumes:
+###> doctrine/doctrine-bundle ###
+  db_data:
+###< doctrine/doctrine-bundle ###

--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -23,6 +23,12 @@ services:
         - db_data:/var/lib/mysql:rw
       ports:
         - 3306:3306
+      entrypoint:
+        - /bin/bash
+        - -c
+        - |
+          echo 'GRANT ALL on `api_test`.* to `api-platform`@`%`;' > /docker-entrypoint-initdb.d/init.sql;
+          /usr/local/bin/docker-entrypoint.sh --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
 ###< doctrine/doctrine-bundle ###
 
 volumes:

--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -5,6 +5,8 @@ services:
   php:
     depends_on:
       - database
+    environment:
+      DATABASE_URL: mysql://${MYSQL_USER}:${MYSQL_PASSWORD}@${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}?serverVersion=${MYSQL_VERSION}
 
 ###> doctrine/doctrine-bundle ###
   database:
@@ -13,12 +15,11 @@ services:
         restart_policy:
           condition: on-failure
       environment:
-        - MYSQL_ROOT_PASSWORD=${DATABASE_ROOT_PASSWORD}
-        - MYSQL_DATABASE=${DATABASE_NAME}
-        - MYSQL_USER=${DATABASE_USER}
-        - MYSQL_PASSWORD=${DATABASE_PASSWORD}
+        MYSQL_ROOT_PASSWORD: ${DATABASE_ROOT_PASSWORD}
+        MYSQL_DATABASE: ${MYSQL_DATABASE}
+        MYSQL_USER: ${MYSQL_USER}
+        MYSQL_PASSWORD: ${MYSQL_PASSWORD}
       volumes:
-        # is this correct?
         - db_data:/var/lib/mysql:rw
       ports:
         - 3306:3306

--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -6,7 +6,7 @@ services:
     depends_on:
       - database
     environment:
-      DATABASE_URL: mysql://${MYSQL_USER:-api-platform}:${MYSQL_PASSWORD:-!ChangeMe!}@${MYSQL_HOST:-127.0.0.1}:${MYSQL_PORT:-3306}/${MYSQL_DATABASE:-api}?serverVersion=${MYSQL_VERSION:-8}
+      DATABASE_URL: mysql://${MYSQL_USER:-api-platform}:${MYSQL_PASSWORD:-!ChangeMe!}@database:${MYSQL_PORT:-3306}/${MYSQL_DATABASE:-api}?serverVersion=${MYSQL_VERSION:-8}
 
 ###> doctrine/doctrine-bundle ###
   database:

--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -15,7 +15,7 @@ services:
         restart_policy:
           condition: on-failure
       environment:
-        MYSQL_ROOT_PASSWORD: ${DATABASE_ROOT_PASSWORD}
+        MYSQL_ROOT_PASSWORD: ${DATABASE_ROOT_PASSWORD:-!ChangeMeRoot!}
         MYSQL_DATABASE: ${MYSQL_DATABASE:-api}
         MYSQL_USER: ${MYSQL_USER:-api-platform}
         MYSQL_PASSWORD: ${MYSQL_PASSWORD:-!ChangeMe!}

--- a/docker-compose.override.postgres.yml
+++ b/docker-compose.override.postgres.yml
@@ -1,0 +1,12 @@
+version: "3.4"
+
+# Development environment override
+services:
+
+###> doctrine/doctrine-bundle ###
+  database:
+    ports:
+      - target: 5432
+        published: 5432
+        protocol: tcp
+###< doctrine/doctrine-bundle ###

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,0 +1,26 @@
+version: "3.4"
+
+# To run postgres as part of Docker
+services:
+  php:
+    depends_on:
+      - database
+
+###> doctrine/doctrine-bundle ###
+  database:
+    image: postgres:${POSTGRES_VERSION:-13}-alpine
+    environment:
+      - POSTGRES_DB=${POSTGRES_DB:-api}
+      # You should definitely change the password in production
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-!ChangeMe!}
+      - POSTGRES_USER=${POSTGRES_USER:-api-platform}
+    volumes:
+      - db_data:/var/lib/postgresql/data:rw
+      # you may use a bind-mounted host directory instead, so that it is harder to accidentally remove the volume and lose all your data!
+      # - ./api/docker/db/data:/var/lib/postgresql/data:rw
+###< doctrine/doctrine-bundle ###
+
+volumes:
+###> doctrine/doctrine-bundle ###
+  db_data:
+###< doctrine/doctrine-bundle ###

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -5,15 +5,17 @@ services:
   php:
     depends_on:
       - database
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:api-platform}:${POSTGRES_PASSWORD:!ChangeMe!}@database:5432/${POSTGRES_DB:api}?serverVersion=13
 
 ###> doctrine/doctrine-bundle ###
   database:
     image: postgres:${POSTGRES_VERSION:-13}-alpine
     environment:
-      - POSTGRES_DB=${POSTGRES_DB:-api}
+      POSTGRES_DB: ${POSTGRES_DB:-api}
       # You should definitely change the password in production
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-!ChangeMe!}
-      - POSTGRES_USER=${POSTGRES_USER:-api-platform}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-!ChangeMe!}
+      POSTGRES_USER: ${POSTGRES_USER:-api-platform}
     volumes:
       - db_data:/var/lib/postgresql/data:rw
       # you may use a bind-mounted host directory instead, so that it is harder to accidentally remove the volume and lose all your data!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
       retries: 3
       start_period: 30s
     environment:
-      DATABASE_URL: ${DATABASE_URL}
       TRUSTED_PROXIES: ${TRUSTED_PROXIES:-127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16}
       TRUSTED_HOSTS: ^${SERVER_NAME:-example\.com|localhost}|caddy$$
       MERCURE_URL: ${CADDY_MERCURE_URL:-http://caddy/.well-known/mercure}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     build:
       context: ./api
       target: api_platform_php
-    depends_on:
-      - database
     restart: unless-stopped
     volumes:
       - php_socket:/var/run/php
@@ -16,7 +14,7 @@ services:
       retries: 3
       start_period: 30s
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-api-platform}:${POSTGRES_PASSWORD:-!ChangeMe!}@database:5432/${POSTGRES_DB:-api}?serverVersion=${POSTGRES_VERSION:-13}
+      DATABASE_URL: ${DATABASE_URL}
       TRUSTED_PROXIES: ${TRUSTED_PROXIES:-127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16}
       TRUSTED_HOSTS: ^${SERVER_NAME:-example\.com|localhost}|caddy$$
       MERCURE_URL: ${CADDY_MERCURE_URL:-http://caddy/.well-known/mercure}
@@ -62,18 +60,6 @@ services:
         published: ${HTTP3_PORT:-443}
         protocol: udp
 
-  database:
-    image: postgres:${POSTGRES_VERSION:-13}-alpine
-    environment:
-      - POSTGRES_DB=${POSTGRES_DB:-api}
-      # You should definitely change the password in production
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-!ChangeMe!}
-      - POSTGRES_USER=${POSTGRES_USER:-api-platform}
-    volumes:
-      - db_data:/var/lib/postgresql/data:rw
-      # you may use a bind-mounted host directory instead, so that it is harder to accidentally remove the volume and lose all your data!
-      # - ./api/docker/db/data:/var/lib/postgresql/data:rw
-
 # Mercure is installed as a Caddy module, prevent the Flex recipe from installing another service
 ###> symfony/mercure-bundle ###
 ###< symfony/mercure-bundle ###
@@ -82,8 +68,5 @@ volumes:
   php_socket:
   caddy_data:
   caddy_config:
-###> doctrine/doctrine-bundle ###
-  db_data:
-###< doctrine/doctrine-bundle ###
 ###> symfony/mercure-bundle ###
 ###< symfony/mercure-bundle ###


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main 
| Tickets       | https://github.com/api-platform/api-platform/pull/1965 https://github.com/api-platform/api-platform/issues/797#issuecomment-683458553 #594 
| License       | MIT
| Doc PR        | TODO

Background: I would like to have the option to have API Platform use mysql instead of postgres. Someone made an [entirely new repo](https://github.com/pcinvent/api-platform-mysql) just to implement this feature, although it's unmaintained.

This PR adds mysql, but keeps postgres as default. It does this by:

* extracting the postgres setup to a separate `docker-compose.postgres.yml` file
* adding mysql setup to a `docker-compose.mysql.yml` file
* adding a top level `.env` file for `docker-compose` to use, which selects postgres by default (but can also be edited to use mysql instead)
* adding a variable to the Dockerfile to select with postgres or mysql
* editing the single migration file to switch between sql for postgres or mysql

To use mysql:

* edit the `.env` file, comment out the postgres lines, and uncomment the following lines:
```
# mysql
DATABASE_ENGINE=mysql
## Dev environment
COMPOSE_FILE=docker-compose.yml:docker-compose.mysql.yml:docker-compose.override.yml
```
* edit the `Dockerfile` and change `ARG DATABASE_ENGINE=postgresql` to `ARG DATABASE_ENGINE=mysql`
* run `docker-compose build`
* run `docker-compose up`

### Additional notes/concerns

* Some changes are needed to `helm/api-platform/values.yaml` but I'm not enough of a Helm/Kubernetes wizard to see what needs to happen. I compared https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml to https://github.com/bitnami/charts/blob/master/bitnami/mysql/values.yaml and tried to intuit what values would be needed, but this should be rather done by someone invested in running mysql on kubernetes.
* I haven't yet written a documentation PR, but will do once I have some feedback on this one.
* The biggest downside with this PR is that it does introduce an `.env` file for `docker-compose` to use, and adds some more `yaml` files - which makes the docker setup less intuitive. However, the big benefit is that it allows for using mysql, while maintaining the current default.
* I haven't written tests for mysql, as this would double the runtime of CI builds.
* The PR template says to update the `CHANGELOG.md` file, but I don't see one.
* This entire PRs commits need to be squashed and merge if it gets approved, as I needed to do a number of exploratory commits and test that they worked.
* re: #594 - it's possible that instead of this PR, using mysql is rather documented in the documentation repo. The benefit is less `docker-compose` complexity (and not worrying about tests not running on mysql); the downside is that it's some manual setup every time a new person wants to run mysql. I leave it to the maintainers to decide whether this PR should be solely on the docs repo.
* re: #1965 - this PR already proposed using the `.env` file, but looks abandoned. There's also a question there about moving more environment variables from the `docker-compose.yml` into the `.env` file, but I had some issues with that, so would rather first land this PR before digging in that more.