### PR TITLE
fix: Admin hanging due to Caddy HTTP2 push error

### DIFF
--- a/api/docker/caddy/Caddyfile
+++ b/api/docker/caddy/Caddyfile
@@ -42,7 +42,6 @@ route {
         {$MERCURE_EXTRA_DIRECTIVES}
     }
     vulcain
-    push
 
     # Add links to the API docs and to the Mercure Hub if not set explicitly (e.g. the PWA)
     header ?Link `</docs.jsonld>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation", </.well-known/mercure>; rel="mercure"`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6.8
| Tickets       | #1825
| License       | MIT

When trying to access /admin every component simply hangs due to an error with Caddy. Removing the push configuration everything seems to work properly.