### PR TITLE
fix: check for migrations in subdirectories

### DIFF
--- a/api/docker/php/docker-entrypoint.sh
+++ b/api/docker/php/docker-entrypoint.sh
@@ -43,7 +43,7 @@ if [ "$1" = 'php-fpm' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
 			echo "The database is now ready and reachable"
 		fi
 
-		if ls -A migrations/*.php >/dev/null 2>&1; then
+		if [ "$( find ./migrations -iname '*.php' -print -quit )" ]; then
 			php bin/console doctrine:migrations:migrate --no-interaction
 		fi
 	fi


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.6.8
| Tickets       | None
| License       | MIT

The entrypoint only checks whether there are PHP files in the ./migrations directory but they can be generated in subdirectories when using the BY_YEAR or BY_YEAR_AND_MONTH configurations.