### PR TITLE
Remove iconv workaround

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -17,12 +17,7 @@ RUN apk add --no-cache \
 		file \
 		gettext \
 		git \
-		gnu-libiconv \
 	;
-
-# install gnu-libiconv and set LD_PRELOAD env to make iconv work fully on Alpine image.
-# see https://github.com/docker-library/php/issues/240#issuecomment-763112749
-ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so
 
 ARG APCU_VERSION=5.1.21
 RUN set -eux; \


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | legacy code removal
| Tickets       | 
| License       | MIT
| Doc PR        | 

This workaround is no longer needed because the problem [was fixed](https://github.com/docker-library/php/issues/240#issuecomment-1064627426) in the php image.
