### PR TITLE
Fixes #1847 "Docker: Launch the php image with a non root user"

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -63,6 +63,8 @@ RUN apk add --no-cache --virtual .pgsql-deps postgresql-dev; \
 
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
+RUN apk add --no-cache su-exec
+
 RUN ln -s $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
 COPY docker/php/conf.d/api-platform.prod.ini $PHP_INI_DIR/conf.d/api-platform.ini
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main for features / current stable version branch for bug fixes <!-- see below -->
| Tickets       | #1847
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

This PR will launch all the commands as the host user (at least, the owner id of file 'composer.json') which is convenient to be able not to generate files as "root" on the host sources : the developer using the api-platform tarball will be able to modify those files without chowning them.

One should also modify the documentation at https://api-platform.com/docs/distribution/#plugging-the-persistence-system in order to change all the `docker-compose exec` references to `docker-compose exec -T -u $(id -u)` so that all the files created will be with the host's user id and not `root`.