### PR TITLE
fix: dependency to schema generator is set to 4.0

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -32,7 +32,7 @@
         "symfony/yaml": "6.1.*"
     },
     "require-dev": {
-        "api-platform/schema-generator": "^4.0",
+        "api-platform/schema-generator": "^5.0",
         "symfony/browser-kit": "6.1.*",
         "symfony/css-selector": "6.1.*",
         "symfony/debug-bundle": "6.1.*",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.0
| Tickets       | #2264
| License       | MIT
| Doc PR        |
 
The 3.0.0 release note advertise the bump to schema-generator 5.0.0 but composer.json still requires ^4.0