### PR TITLE
Removes experimental_http3 as now standard

### DIFF
--- a/api/docker/caddy/Caddyfile
+++ b/api/docker/caddy/Caddyfile
@@ -3,9 +3,6 @@
     {$DEBUG}
     # HTTP/3 support
     servers {
-        protocol {
-            experimental_http3
-        }
     }
 }
 

--- a/api/docker/caddy/Caddyfile
+++ b/api/docker/caddy/Caddyfile
@@ -1,9 +1,6 @@
 {
     # Debug
     {$DEBUG}
-    # HTTP/3 support
-    servers {
-    }
 }
 
 {$SERVER_NAME}


### PR DESCRIPTION
The experimental_http3 server protocol option is now failing in Caddyfile as the option has been removed.

HTTP/3 support is now standard.

See…
- https://github.com/caddyserver/caddy/pull/4707
- https://github.com/caddyserver/caddy/pull/4707/files#diff-51e94e99e336177354509e6e1ea884faca26dd3e9ff0bc066581f2cc52df03deR195


| Q             | A
| ------------- | ---
| Branch?       | main (can't see any other branches to target as a bug fix)
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

It appears that support for the experimental_http3 server protocol option has been removed from Caddy.  [This PR](https://github.com/caddyserver/caddy/pull/4707/files#diff-51e94e99e336177354509e6e1ea884faca26dd3e9ff0bc066581f2cc52df03deR195) shows that the default options now include h3 (HTTP/3).

I'm not sure how I would 'test' this, other than have existing tests pass as the server won't now run without this change?!  Please advise if more is needed here.