### PR TITLE
Fixed: Caddy build not working with latest dunglas/mercure|vulcain

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -120,20 +120,11 @@ RUN set -eux; \
 
 RUN rm -f .env.local.php
 
-# Build Caddy with the Mercure and Vulcain modules
-FROM caddy:2-builder-alpine AS app_caddy_builder
-
-RUN xcaddy build \
-	--with github.com/dunglas/mercure \
-	--with github.com/dunglas/mercure/caddy \
-	--with github.com/dunglas/vulcain \
-	--with github.com/dunglas/vulcain/caddy
-
 # Caddy image
 FROM caddy:2-alpine AS app_caddy
 
 WORKDIR /srv/app
 
-COPY --from=app_caddy_builder --link /usr/bin/caddy /usr/bin/caddy
+COPY --from=dunglas/mercure:v0.14 /usr/bin/caddy /usr/bin/caddy
 COPY --from=app_php --link /srv/app/public public/
 COPY --link docker/caddy/Caddyfile /etc/caddy/Caddyfile


### PR DESCRIPTION
I think the main branch is ok for such small "fix".

PS: Don't know if vulcain is still working (does not use it in current dev), seems there are seperate images:
https://hub.docker.com/u/dunglas

But normally vulcain should be included in mercure-image. The vulcain image got last update before two years...

Greez