### PR TITLE
remove /ping logs from php-fpm

### DIFF
--- a/api/docker/php/php-fpm.d/zz-docker.conf
+++ b/api/docker/php/php-fpm.d/zz-docker.conf
@@ -6,3 +6,4 @@ process_control_timeout = 20
 listen = /var/run/php/php-fpm.sock
 listen.mode = 0666
 ping.path = /ping
+access.suppress_path[] = /ping


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | no ticket
| License       | MIT
| Doc PR        | no doc

Since PHP-FPM 8.2, it's possible to exclude some routes to log.

https://bugs.php.net/bug.php?id=80428

I think that logging the healthcheck route `/ping` is not useful and can be remove.