### PR TITLE
Fix for docker build issue for PWA

### DIFF
--- a/pwa/Dockerfile
+++ b/pwa/Dockerfile
@@ -58,8 +58,8 @@ COPY --from=builder --link /srv/app/public ./public
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --link --chown=nextjs:nodejs /srv/app/.next/standalone ./
-COPY --from=builder --link --chown=nextjs:nodejs /srv/app/.next/static ./.next/static
+COPY --from=builder --link --chown=1001:1001 /srv/app/.next/standalone ./
+COPY --from=builder --link --chown=1001:1001 /srv/app/.next/static ./.next/static
 
 USER nextjs
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | #2412
| License       | MIT
| Doc PR        | api-platform/docs

This PR is fixing the docker build issue with `--chown`, blocking the production image building.