### PR TITLE
Fixes #2417 : PNPM 8 new release breaking change

### DIFF
--- a/pwa/Dockerfile
+++ b/pwa/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /srv/app
 
 RUN corepack enable && \
-	corepack prepare --activate pnpm@latest && \
+	corepack prepare --activate pnpm@latest-7 && \
 	pnpm config -g set store-dir /.pnpm-store
 
 # Next.js collects completely anonymous telemetry data about general usage.


### PR DESCRIPTION
PNPM 8 new release breaking change in lock file definition prevent building docker container

| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | #2417
| License       | MIT
| Doc PR        | api-platform

