### PR TITLE
helm - update pod when configmap changed

### DIFF
--- a/helm/api-platform/templates/deployment.yaml
+++ b/helm/api-platform/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         {{- with .Values.podAnnotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/helm/api-platform/templates/deployment.yaml
+++ b/helm/api-platform/templates/deployment.yaml
@@ -13,10 +13,11 @@ spec:
       {{- include "api-platform.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "api-platform.selectorLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | 
| License       | MIT
| Doc PR        | 

Before:
When the config map changed, the pods have to be restart manually to get the new configuration.

Proposition:
By adding an annotation in pods, they are restarted when the configmap change.
The annotation follow this documentation: https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments