### PR TITLE
Fix Dockerfile last change

### DIFF
--- a/pwa/Dockerfile
+++ b/pwa/Dockerfile
@@ -52,7 +52,7 @@ ENV NODE_ENV production
 # Delete the following line in case you want to enable telemetry during runtime.
 ENV NEXT_TELEMETRY_DISABLED 1
 
-RUN addgroup --system --gid 1001 nodejs \
+RUN addgroup --system --gid 1001 nodejs && \
 	adduser --system --uid 1001 nextjs
 
 COPY --from=builder --link /srv/app/public ./public


### PR DESCRIPTION
First time trying to use api-platform.
I downloaded it and got the known 3.0.10 caddy build fail. But then trying main I got another error building the "pwa".
```
failed to solve: executor failed running [/bin/sh -c addgroup --system --gid 1001 nodejs        adduser --system --uid 1001 nextjs]: exit code: 1
```
Looks like last Lint conected the 2 lines without adding &&