### PR TITLE
ci: improved Docker images and GitHub actions, CI execution time divided by 5!

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,17 +7,10 @@ on:
   pull_request: ~
   workflow_dispatch: ~
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
-    permissions:
-      contents: 'read'
-      id-token: 'write'
     steps:
       -
         name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,31 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - name: Checkout
+      -
+        name: Checkout
         uses: actions/checkout@v3
-      - name: Pull images
-        run: docker compose pull --ignore-pull-failures || true
-      - name: Start services
-        run: docker compose up --build -d
-      - name: Wait for services
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Build Docker images
+        uses: docker/bake-action@v3
+        with:
+          pull: true
+          load: true
+          files: |
+            docker-compose.yml
+            docker-compose.override.yml
+          set: |
+            *.cache-from=type=gha,scope=${{github.ref}}
+            *.cache-from=type=gha,scope=refs/heads/main
+            *.cache-to=type=gha,scope=${{github.ref}},mode=max
+      - run: docker images
+      -
+        name: Start services
+        run: docker compose up --no-build -d
+      -
+        name: Wait for services
         run: |
           while status="$(docker inspect --format="{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}" "$(docker compose ps -q php)")"; do
             case $status in
@@ -39,27 +57,36 @@ jobs:
             esac
           done
           exit 1
-      - name: Check HTTP reachability
+      -
+        name: Check HTTP reachability
         run: curl -v -o /dev/null http://localhost
-      - name: Check API reachability
+      -
+        name: Check API reachability
         run: curl -vk -o /dev/null https://localhost
-      - name: Check PWA reachability
+      -
+        name: Check PWA reachability
         run: "curl -vk -o /dev/null -H 'Accept: text/html' https://localhost"
-      - name: Create test database
-        run: |
-          docker compose exec -T php bin/console -e test doctrine:database:create
-          docker compose exec -T php bin/console -e test doctrine:migrations:migrate --no-interaction
-      - name: PHPUnit
+      -
+        name: Create test database
+        run: docker compose exec -T php bin/console -e test doctrine:database:create
+      -
+        name: Run migrations
+        run: docker compose exec -T php bin/console -e test doctrine:migrations:migrate --no-interaction
+      -
+        name: Run PHPUnit
         run: docker compose exec -T php bin/phpunit
-      - name: Doctrine Schema Validator
-        run: docker compose exec -T php bin/console doctrine:schema:validate
+      -
+        name: Doctrine Schema Validator
+        run: docker compose exec -T php bin/console -e test doctrine:schema:validate
   lint:
     name: Docker Lint
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      -
+        name: Checkout
         uses: actions/checkout@v3
-      - name: Lint Dockerfiles
+      -
+        name: Lint Dockerfiles
         uses: hadolint/hadolint-action@v3.1.0
         with:
             recursive: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,6 @@ jobs:
             *.cache-from=type=gha,scope=${{github.ref}}
             *.cache-from=type=gha,scope=refs/heads/main
             *.cache-to=type=gha,scope=${{github.ref}},mode=max
-      - run: docker images
       -
         name: Start services
         run: docker compose up --no-build -d

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   pull_request: ~
   workflow_dispatch: ~
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: Tests
@@ -33,22 +37,7 @@ jobs:
             *.cache-to=type=gha,scope=${{github.ref}},mode=max
       -
         name: Start services
-        run: docker compose up --no-build -d
-      -
-        name: Wait for services
-        run: |
-          while status="$(docker inspect --format="{{if .Config.Healthcheck}}{{print .State.Health.Status}}{{end}}" "$(docker compose ps -q php)")"; do
-            case $status in
-              starting) sleep 1;;
-              healthy) exit 0;;
-              unhealthy)
-                docker compose ps
-                docker compose logs
-                exit 1
-              ;;
-            esac
-          done
-          exit 1
+        run: docker compose up --wait --no-build
       -
         name: Check HTTP reachability
         run: curl -v -o /dev/null http://localhost

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -17,7 +17,7 @@ FROM curlimages/curl:8.1.2 AS curl_base
 
 
 # Prod image
-FROM php_base AS app_php
+FROM php_base AS app_php_base
 
 ENV APP_ENV=prod
 
@@ -75,6 +75,27 @@ ENV PATH="${PATH}:/root/.composer/vendor/bin"
 
 COPY --from=composer_base --link /composer /usr/bin/composer
 
+
+# Dev image
+FROM app_php_base AS app_php_dev
+
+ENV APP_ENV=dev XDEBUG_MODE=off
+VOLUME /srv/app/var/
+
+RUN rm "$PHP_INI_DIR/conf.d/app.prod.ini"; \
+	mv "$PHP_INI_DIR/php.ini" "$PHP_INI_DIR/php.ini-production"; \
+	mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
+
+COPY --link docker/php/conf.d/app.dev.ini $PHP_INI_DIR/conf.d/
+
+RUN set -eux; \
+	install-php-extensions \
+    	xdebug \
+    ;
+
+# Prod image
+FROM app_php_base AS app_php
+
 # prevent the reinstallation of vendors at every changes in the source code
 COPY --link composer.* symfony.* ./
 RUN set -eux; \
@@ -92,24 +113,6 @@ RUN set -eux; \
 	composer run-script --no-dev post-install-cmd; \
 	chmod +x bin/console; sync;
 
-# Dev image
-FROM app_php AS app_php_dev
-
-ENV APP_ENV=dev XDEBUG_MODE=off
-VOLUME /srv/app/var/
-
-RUN rm "$PHP_INI_DIR/conf.d/app.prod.ini"; \
-	mv "$PHP_INI_DIR/php.ini" "$PHP_INI_DIR/php.ini-production"; \
-	mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
-
-COPY --link docker/php/conf.d/app.dev.ini $PHP_INI_DIR/conf.d/
-
-RUN set -eux; \
-	install-php-extensions \
-    	xdebug \
-    ;
-
-RUN rm -f .env.local.php
 
 # Download Caddy with the Mercure and Vulcain modules
 FROM curl_base AS caddy_downloader

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -8,7 +8,6 @@ FROM php:8.2-fpm-alpine AS php_base
 FROM mlocati/php-extension-installer:2 AS php_extension_installer_base
 FROM composer/composer:2-bin AS composer_base
 FROM caddy:2-alpine AS caddy_base
-FROM curlimages/curl:8.1.2 AS curl_base
 
 
 # The different stages of this Dockerfile are meant to be built into separate images
@@ -112,25 +111,15 @@ RUN set -eux; \
 	chmod +x bin/console; sync;
 
 
-# Download Caddy with the Mercure and Vulcain modules
-FROM curl_base AS caddy_downloader
-
-WORKDIR /downloads
-
-RUN curl \
-	--url-query "os=$TARGETOS" \
-	--url-query "arg=$TARGETARCH" \
-	--url-query 'p=github.com/dunglas/mercure/caddy' \
-	--url-query 'p=github.com/dunglas/vulcain/caddy' \
-	-o /downloads/caddy \
-	https://caddyserver.com/api/download
-
-
 # Caddy image
 FROM caddy_base AS app_caddy
 
+ARG TARGETARCH
+
 WORKDIR /srv/app
 
-COPY --from=caddy_downloader --chmod=500 /downloads/caddy /usr/bin/caddy
+# Download Caddy compiled with the Mercure and Vulcain modules
+ADD --chmod=500 https://caddyserver.com/api/download?os=linux&arch=$TARGETARCH&p=github.com/dunglas/mercure/caddy&p=github.com/dunglas/vulcain/caddy /usr/bin/caddy
+
 COPY --link docker/caddy/Caddyfile /etc/caddy/Caddyfile
 COPY --from=app_php_prod --link /srv/app/public public/

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -51,9 +51,7 @@ RUN set -eux; \
 ###< doctrine/doctrine-bundle ###
 ###< recipes ###
 
-RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 COPY --link docker/php/conf.d/app.ini $PHP_INI_DIR/conf.d/
-COPY --link docker/php/conf.d/app.prod.ini $PHP_INI_DIR/conf.d/
 
 COPY --link docker/php/php-fpm.d/zz-docker.conf /usr/local/etc/php-fpm.d/zz-docker.conf
 RUN mkdir -p /var/run/php
@@ -82,10 +80,7 @@ FROM app_php_base AS app_php_dev
 ENV APP_ENV=dev XDEBUG_MODE=off
 VOLUME /srv/app/var/
 
-RUN rm "$PHP_INI_DIR/conf.d/app.prod.ini"; \
-	mv "$PHP_INI_DIR/php.ini" "$PHP_INI_DIR/php.ini-production"; \
-	mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
-
+COPY --link $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini
 COPY --link docker/php/conf.d/app.dev.ini $PHP_INI_DIR/conf.d/
 
 RUN set -eux; \
@@ -95,6 +90,9 @@ RUN set -eux; \
 
 # Prod image
 FROM app_php_base AS app_php
+
+COPY --link $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
+COPY --link docker/php/conf.d/app.prod.ini $PHP_INI_DIR/conf.d/
 
 # prevent the reinstallation of vendors at every changes in the source code
 COPY --link composer.* symfony.* ./

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -19,8 +19,6 @@ FROM curlimages/curl:8.1.2 AS curl_base
 # Prod image
 FROM php_base AS app_php_base
 
-ENV APP_ENV=prod
-
 WORKDIR /srv/app
 
 # php extensions installer: https://github.com/mlocati/docker-php-extension-installer
@@ -80,7 +78,8 @@ FROM app_php_base AS app_php_dev
 ENV APP_ENV=dev XDEBUG_MODE=off
 VOLUME /srv/app/var/
 
-COPY --link $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini
+RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
+
 COPY --link docker/php/conf.d/app.dev.ini $PHP_INI_DIR/conf.d/
 
 RUN set -eux; \
@@ -89,16 +88,17 @@ RUN set -eux; \
     ;
 
 # Prod image
-FROM app_php_base AS app_php
+FROM app_php_base AS app_php_prod
 
-COPY --link $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
+ENV APP_ENV=prod
+
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 COPY --link docker/php/conf.d/app.prod.ini $PHP_INI_DIR/conf.d/
 
 # prevent the reinstallation of vendors at every changes in the source code
 COPY --link composer.* symfony.* ./
 RUN set -eux; \
-	composer install --prefer-dist --no-dev --no-autoloader --no-scripts --no-progress; \
-	composer clear-cache
+	composer install --no-cache --prefer-dist --no-dev --no-autoloader --no-scripts --no-progress
 
 # copy sources
 COPY --link . ./
@@ -133,4 +133,4 @@ WORKDIR /srv/app
 
 COPY --from=caddy_downloader --chmod=500 /downloads/caddy /usr/bin/caddy
 COPY --link docker/caddy/Caddyfile /etc/caddy/Caddyfile
-COPY --from=app_php --link /srv/app/public public/
+COPY --from=app_php_prod --link /srv/app/public public/

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -8,21 +8,13 @@ FROM php:8.2-fpm-alpine AS php_base
 FROM mlocati/php-extension-installer:2 AS php_extension_installer_base
 FROM composer/composer:2-bin AS composer_base
 FROM caddy:2-alpine AS caddy_base
-FROM caddy:2.7-builder-alpine AS caddy_builder_base
+FROM curlimages/curl:8.1.2 AS curl_base
 
 
 # The different stages of this Dockerfile are meant to be built into separate images
 # https://docs.docker.com/develop/develop-images/multistage-build/#stop-at-a-specific-build-stage
 # https://docs.docker.com/compose/compose-file/#target
 
-
-# Build Caddy with the Mercure and Vulcain modules
-FROM caddy_builder_base AS app_caddy_builder
-
-# Temporary fix for https://github.com/dunglas/mercure/issues/770
-RUN xcaddy build v2.6.4 \
-	--with github.com/dunglas/mercure/caddy \
-	--with github.com/dunglas/vulcain/caddy
 
 # Prod image
 FROM php_base AS app_php
@@ -119,11 +111,25 @@ RUN set -eux; \
 
 RUN rm -f .env.local.php
 
+# Download Caddy with the Mercure and Vulcain modules
+FROM curl_base AS caddy_downloader
+
+WORKDIR /downloads
+
+RUN curl \
+	--url-query "os=$TARGETOS" \
+	--url-query "arg=$TARGETARCH" \
+	--url-query 'p=github.com/dunglas/mercure/caddy' \
+	--url-query 'p=github.com/dunglas/vulcain/caddy' \
+	-o /downloads/caddy \
+	https://caddyserver.com/api/download
+
+
 # Caddy image
 FROM caddy_base AS app_caddy
 
 WORKDIR /srv/app
 
-COPY --from=app_caddy_builder --link /usr/bin/caddy /usr/bin/caddy
-COPY --from=app_php --link /srv/app/public public/
+COPY --from=caddy_downloader --chmod=500 /downloads/caddy /usr/bin/caddy
 COPY --link docker/caddy/Caddyfile /etc/caddy/Caddyfile
+COPY --from=app_php --link /srv/app/public public/

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -16,7 +16,7 @@ FROM curlimages/curl:8.1.2 AS curl_base
 # https://docs.docker.com/compose/compose-file/#target
 
 
-# Prod image
+# Base image
 FROM php_base AS app_php_base
 
 WORKDIR /srv/app
@@ -80,12 +80,12 @@ VOLUME /srv/app/var/
 
 RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 
-COPY --link docker/php/conf.d/app.dev.ini $PHP_INI_DIR/conf.d/
-
 RUN set -eux; \
 	install-php-extensions \
     	xdebug \
     ;
+
+COPY --link docker/php/conf.d/app.dev.ini $PHP_INI_DIR/conf.d/
 
 # Prod image
 FROM app_php_base AS app_php_prod

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -20,9 +20,6 @@ FROM php_upstream AS php_base
 
 WORKDIR /srv/app
 
-# php extensions installer: https://github.com/mlocati/docker-php-extension-installer
-COPY --from=php_extension_installer_upstream --link /usr/bin/install-php-extensions /usr/local/bin/
-
 # persistent / runtime deps
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
@@ -32,6 +29,9 @@ RUN apk add --no-cache \
 		gettext \
 		git \
 	;
+
+# php extensions installer: https://github.com/mlocati/docker-php-extension-installer
+COPY --from=php_extension_installer_upstream --link /usr/bin/install-php-extensions /usr/local/bin/
 
 RUN set -eux; \
     install-php-extensions \

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,10 +4,10 @@
 
 
 # Versions
-FROM php:8.2-fpm-alpine AS php_base
-FROM mlocati/php-extension-installer:2 AS php_extension_installer_base
-FROM composer/composer:2-bin AS composer_base
-FROM caddy:2-alpine AS caddy_base
+FROM php:8.2-fpm-alpine AS php_upstream
+FROM mlocati/php-extension-installer:2 AS php_extension_installer_upstream
+FROM composer/composer:2-bin AS composer_upstream
+FROM caddy:2-alpine AS caddy_upstream
 
 
 # The different stages of this Dockerfile are meant to be built into separate images
@@ -15,13 +15,13 @@ FROM caddy:2-alpine AS caddy_base
 # https://docs.docker.com/compose/compose-file/#target
 
 
-# Base image
-FROM php_base AS app_php_base
+# Base PHP image
+FROM php_upstream AS php_base
 
 WORKDIR /srv/app
 
 # php extensions installer: https://github.com/mlocati/docker-php-extension-installer
-COPY --from=php_extension_installer_base --link /usr/bin/install-php-extensions /usr/local/bin/
+COPY --from=php_extension_installer_upstream --link /usr/bin/install-php-extensions /usr/local/bin/
 
 # persistent / runtime deps
 # hadolint ignore=DL3018
@@ -68,11 +68,11 @@ CMD ["php-fpm"]
 ENV COMPOSER_ALLOW_SUPERUSER=1
 ENV PATH="${PATH}:/root/.composer/vendor/bin"
 
-COPY --from=composer_base --link /composer /usr/bin/composer
+COPY --from=composer_upstream --link /composer /usr/bin/composer
 
 
-# Dev image
-FROM app_php_base AS app_php_dev
+# Dev PHP image
+FROM php_base AS php_dev
 
 ENV APP_ENV=dev XDEBUG_MODE=off
 VOLUME /srv/app/var/
@@ -86,8 +86,8 @@ RUN set -eux; \
 
 COPY --link docker/php/conf.d/app.dev.ini $PHP_INI_DIR/conf.d/
 
-# Prod image
-FROM app_php_base AS app_php_prod
+# Prod PHP image
+FROM php_base AS php_prod
 
 ENV APP_ENV=prod
 
@@ -111,8 +111,8 @@ RUN set -eux; \
 	chmod +x bin/console; sync;
 
 
-# Caddy image
-FROM caddy_base AS app_caddy
+# Base Caddy image
+FROM caddy_upstream AS caddy_base
 
 ARG TARGETARCH
 
@@ -122,4 +122,8 @@ WORKDIR /srv/app
 ADD --chmod=500 https://caddyserver.com/api/download?os=linux&arch=$TARGETARCH&p=github.com/dunglas/mercure/caddy&p=github.com/dunglas/vulcain/caddy /usr/bin/caddy
 
 COPY --link docker/caddy/Caddyfile /etc/caddy/Caddyfile
-COPY --from=app_php_prod --link /srv/app/public public/
+
+# Prod Caddy image
+FROM caddy_base AS caddy_prod
+
+COPY --from=php_prod --link /srv/app/public public/

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,7 +4,8 @@ version: "3.4"
 services:
   php:
     build:
-      target: app_php_dev
+      context: ./api
+      target: php_dev
     volumes:
       - ./api:/srv/app
       - ./api/docker/php/conf.d/app.dev.ini:/usr/local/etc/php/conf.d/app.dev.ini:ro
@@ -31,6 +32,9 @@ services:
       WATCHPACK_POLLING: "true"
 
   caddy:
+    build:
+      context: api/
+      target: caddy_base
     volumes:
       - ./api/public:/srv/app/public:ro
       - ./api/docker/caddy/Caddyfile:/etc/caddy/Caddyfile:ro

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,11 +3,22 @@ version: "3.4"
 # Production environment override
 services:
   php:
+    build:
+      context: ./api
+      target: php_prod
     environment:
       APP_SECRET: ${APP_SECRET}
       MERCURE_JWT_SECRET: ${CADDY_MERCURE_JWT_SECRET}
 
+  pwa:
+     build:
+      context: ./pwa
+      target: prod
+
   caddy:
+    build:
+      context: api/
+      target: caddy_prod
     environment:
       MERCURE_PUBLISHER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET}
       MERCURE_SUBSCRIBER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,6 @@ version: "3.4"
 services:
   php:
     image: app-php
-    build:
-      context: ./api
-      target: app_php_prod
     depends_on:
       - database
     restart: unless-stopped
@@ -26,17 +23,11 @@ services:
 
   pwa:
     image: app-pwa
-    build:
-      context: ./pwa
-      target: prod
     environment:
       NEXT_PUBLIC_ENTRYPOINT: http://caddy
 
   caddy:
     image: app-caddy
-    build:
-      context: api/
-      target: app_caddy
     depends_on:
       - php
       - pwa

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   php:
-    image: api-platform-php
+    image: app-php
     build:
       context: ./api
       target: app_php_prod
@@ -17,7 +17,7 @@ services:
       retries: 3
       start_period: 30s
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-app}:${POSTGRES_PASSWORD:-!ChangeMe!}@database:5432/${POSTGRES_DB:-app}?serverVersion=${POSTGRES_VERSION:-14}
+      DATABASE_URL: postgresql://${POSTGRES_USER:-app}:${POSTGRES_PASSWORD:-!ChangeMe!}@database:5432/${POSTGRES_DB:-app}?serverVersion=${POSTGRES_VERSION:-15}
       TRUSTED_PROXIES: ${TRUSTED_PROXIES:-127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16}
       TRUSTED_HOSTS: ^${SERVER_NAME:-example\.com|localhost}|caddy$$
       MERCURE_URL: ${CADDY_MERCURE_URL:-http://caddy/.well-known/mercure}
@@ -25,7 +25,7 @@ services:
       MERCURE_JWT_SECRET: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
 
   pwa:
-    image: api-platform-pwa
+    image: app-pwa
     build:
       context: ./pwa
       target: prod
@@ -33,7 +33,7 @@ services:
       NEXT_PUBLIC_ENTRYPOINT: http://caddy
 
   caddy:
-    image: api-platform-caddy
+    image: app-caddy
     build:
       context: api/
       target: app_caddy
@@ -66,7 +66,7 @@ services:
 
 ###> doctrine/doctrine-bundle ###
   database:
-    image: postgres:${POSTGRES_VERSION:-14}-alpine
+    image: postgres:${POSTGRES_VERSION:-15}-alpine
     environment:
       - POSTGRES_DB=${POSTGRES_DB:-app}
       # You should definitely change the password in production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.4"
 
 services:
   php:
+    image: api-platform-php
     build:
       context: ./api
       target: app_php
@@ -24,6 +25,7 @@ services:
       MERCURE_JWT_SECRET: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
 
   pwa:
+    image: api-platform-pwa
     build:
       context: ./pwa
       target: prod
@@ -31,6 +33,7 @@ services:
       NEXT_PUBLIC_ENTRYPOINT: http://caddy
 
   caddy:
+    image: api-platform-caddy
     build:
       context: api/
       target: app_caddy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: api-platform-php
     build:
       context: ./api
-      target: app_php
+      target: app_php_prod
     depends_on:
       - database
     restart: unless-stopped

--- a/helm/api-platform/README.md
+++ b/helm/api-platform/README.md
@@ -1,6 +1,6 @@
 # Deploying to a Kubernetes Cluster
 
-API Platform comes with a native integration with [Kubernetes](https://kubernetes.io/) and the [Helm](https://helm.sh/)
+API Platform comes with native integration with [Kubernetes](https://kubernetes.io/) and the [Helm](https://helm.sh/)
 package manager.
 
 [Learn how to deploy in the dedicated documentation entry](https://api-platform.com/docs/deployment/kubernetes/).

--- a/pwa/Dockerfile
+++ b/pwa/Dockerfile
@@ -2,11 +2,11 @@
 
 
 # Versions
-FROM node:18-alpine AS node_base
+FROM node:18-alpine AS node_upstream
 
 
 # Base stage for dev and build
-FROM node_base AS builder_base
+FROM node_upstream AS base
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 # hadolint ignore=DL3018
@@ -24,18 +24,8 @@ RUN corepack enable && \
 ENV NEXT_TELEMETRY_DISABLED 1
 
 
-# Deps stage, preserve dependencies in cache as long as the lockfile isn't changed
-FROM builder_base AS deps
-
-COPY --link pnpm-lock.yaml ./
-RUN pnpm fetch
-
-COPY --link . .
-RUN pnpm install --offline --frozen-lockfile
-
-
 # Development image
-FROM deps as dev
+FROM base as dev
 
 EXPOSE 3000
 ENV PORT 3000
@@ -44,23 +34,27 @@ ENV HOSTNAME localhost
 CMD ["sh", "-c", "pnpm install; pnpm dev"]
 
 
-FROM builder_base AS builder
-COPY --link . .
-COPY --from=deps --link /srv/app/node_modules ./node_modules
+FROM base AS builder
 
-RUN pnpm run build
+COPY --link pnpm-lock.yaml ./
+RUN pnpm fetch --prod
+
+COPY --link . .
+
+RUN	pnpm install --frozen-lockfile --offline --prod && \
+	pnpm run build
 
 
 # Production image, copy all the files and run next
-FROM node_base AS prod
+FROM node_upstream AS prod
+
 WORKDIR /srv/app
 
 ENV NODE_ENV production
 # Delete the following line in case you want to enable telemetry during runtime.
 ENV NEXT_TELEMETRY_DISABLED 1
 
-RUN \
-	addgroup --system --gid 1001 nodejs; \
+RUN addgroup --system --gid 1001 nodejs; \
 	adduser --system --uid 1001 nextjs
 
 COPY --from=builder --link /srv/app/public ./public


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

CI runs reduced from 5 to 7mn to about 1mn!

* Revamp PHP and Next.js `Dockerfile`s to improve caching
* Download a binary version of Caddy instead of compiling it locally
* Revamp the GitHub Actions workflow to use Docker Bake and cache layers in GitHub Actions' cache