### PR TITLE
ci: use local buildx install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
             --load \
             --file docker-compose.yml \
             --file docker-compose.override.yml \
-            --set *.cache-from=type=gha,scope=${{github.ref}} \
-            --set *.cache-from=type=gha,scope=refs/heads/main \
-            --set *.cache-to=type=gha,scope=${{github.ref}},mode=max
+            --set '*.cache-from=type=gha,scope=${{github.ref}}' \
+            --set '*.cache-from=type=gha,scope=refs/heads/main' \
+            --set '*.cache-to=type=gha,scope=${{github.ref}},mode=max'
       -
         name: Start services
         run: docker compose up --wait --no-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,21 +20,16 @@ jobs:
         name: Checkout
         uses: actions/checkout@v3
       -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      -
         name: Build Docker images
-        uses: docker/bake-action@v3
-        with:
-          pull: true
-          load: true
-          files: |
-            docker-compose.yml
-            docker-compose.override.yml
-          set: |
-            *.cache-from=type=gha,scope=${{github.ref}}
-            *.cache-from=type=gha,scope=refs/heads/main
-            *.cache-to=type=gha,scope=${{github.ref}},mode=max
+        run: |
+          docker buildx bake \
+            --pull \
+            --load \
+            --file docker-compose.yml \
+            --file docker-compose.override.yml \
+            --set *.cache-from=type=gha,scope=${{github.ref}} \
+            --set *.cache-from=type=gha,scope=refs/heads/main \
+            --set *.cache-to=type=gha,scope=${{github.ref}},mode=max
       -
         name: Start services
         run: docker compose up --wait --no-build


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Docker Buildx is preinstalled in GHA runners. Let's use this instead of downloading a new one.
