### PR TITLE
feat: allow to prefix Docker images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   php:
-    image: app-php
+    image: ${IMAGES_PREFIX:-}app-php
     depends_on:
       - database
     restart: unless-stopped
@@ -22,12 +22,12 @@ services:
       MERCURE_JWT_SECRET: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
 
   pwa:
-    image: app-pwa
+    image: ${IMAGES_PREFIX:-}app-pwa
     environment:
       NEXT_PUBLIC_ENTRYPOINT: http://caddy
 
   caddy:
-    image: app-caddy
+    image: ${IMAGES_PREFIX:-}app-caddy
     depends_on:
       - php
       - pwa


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | n/a
| License       | MIT
| Doc PR        | todo

This eases the process of using Docker Bake to build images needed for Kubernetes deployment.
This also allows us to easily push the images to a registry.