### PR TITLE
feat: rename CADDY_DEBUG to CADDY_GLOBAL_OPTIONS

### DIFF
--- a/api/docker/caddy/Caddyfile
+++ b/api/docker/caddy/Caddyfile
@@ -1,6 +1,5 @@
 {
-    # Debug
-    {$CADDY_DEBUG}
+    {$CADDY_GLOBAL_OPTIONS}
 }
 
 {$SERVER_NAME}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Closes #..., closes #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | n/a

Actually, any global Caddy option can be injected in the `CADDY_DEBUG`env var. Let's rename it to make this more intuitive.

Helps for https://github.com/api-platform/api-platform/pull/2487#issuecomment-1691308193.