### PR TITLE
feat: run composer install only if vendors aren't present

### DIFF
--- a/api/docker/php/docker-entrypoint.sh
+++ b/api/docker/php/docker-entrypoint.sh
@@ -1,13 +1,8 @@
 #!/bin/sh
 set -e
 
-# first arg is `-f` or `--some-option`
-if [ "${1#-}" != "$1" ]; then
-	set -- php-fpm "$@"
-fi
-
 if [ "$1" = 'php-fpm' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
-	if [ "$APP_ENV" != 'prod' ]; then
+	if [ ! -d 'vendor/' ]; then
 		composer install --prefer-dist --no-progress --no-interaction
 	fi
 


### PR DESCRIPTION
In the typical case, vendors are already up to date. Skipping useless calls to composer install will speed up the boot time.

| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a