### PR TITLE
fix: add json required format

### DIFF
--- a/api/config/packages/api_platform.yaml
+++ b/api/config/packages/api_platform.yaml
@@ -5,6 +5,7 @@ api_platform:
     mercure: ~
     formats:
         jsonld: ['application/ld+json']
+        json: ['application/json']
     docs_formats:
         jsonld: ['application/ld+json']
         jsonopenapi: ['application/vnd.openapi+json']


### PR DESCRIPTION
API Platform is unable to return a `application/problem+json` response if `application/json` format is not configured. See reproducer here: https://github.com/api-platform/demo/actions/runs/6392944298/job/17351213781