### PR TITLE
docs: fix link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ It means that you can:
 
 ## Install
 
-[Read the official "Getting Started" guide](https://api-platform.com/docs/distribution).
+[Read the official "Getting Started" guide](https://api-platform.com/docs/distribution/).
 
 ## Credits
 


### PR DESCRIPTION
In the README.md, the link https://api-platform.com/docs/distribution redirect to https://api-platform.com/docs/distribution/distribution/
