### PR TITLE
Feat : Force the local environment  to use by defaut Http

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -13,6 +13,7 @@ services:
       #  from the bind-mount for better performance by enabling the next line:
       #- /app/vendor
     environment:
+      SERVER_NAME: "${SERVER_NAME:-http://localhost}"
       MERCURE_EXTRA_DIRECTIVES: demo
       # See https://xdebug.org/docs/all_settings#mode
       XDEBUG_MODE: "${XDEBUG_MODE:-off}"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | 
| License       | MIT
| Doc PR        | n/a

When we code with defaut configuration in dev environement. Caddy force the redirection to https.

Then has several troubleshooting, the web explorer want a certificat SSL and Xdebug with https
