### PR TITLE
Bug - Use Docker Composer For update-deps.sh

### DIFF
--- a/update-deps.sh
+++ b/update-deps.sh
@@ -11,8 +11,7 @@ docker compose run php /bin/sh -c 'composer update; composer outdated'
 docker compose run pwa /bin/sh -c 'pnpm install; pnpm update; pnpm outdated'
 
 # Update Symfony recipes
-cd api
-composer recipes:update
+docker compose run php /bin/sh -c 'cd api && composer recipes:update'
 
 echo 'Run `git diff` and carefully inspect the changes made by the recipes.'
 echo 'Run `docker compose up --force-recreate` now and check that everything is fine!'


### PR DESCRIPTION
Running `update-deps.sh` failed for me since I don't have PHP or composer installed on my host system.
The other commands regarding composer are executed within the context of the php container and using that
for the recipe updates will keep everything contained to the docker environment.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | 

