### PR TITLE
frankenphp fmt

### DIFF
--- a/api/frankenphp/Caddyfile
+++ b/api/frankenphp/Caddyfile
@@ -11,7 +11,7 @@
 	order php_server before file_server
 }
 
-{$CADDY_EXTRA_CONFIG}
+{$CADDY_EXTRA_CONFIG} 
 
 {$SERVER_NAME:localhost} {
 	log {
@@ -28,20 +28,20 @@
 
 	root * /app/public
 	encode {
-		zstd 
-		br 
+		zstd
+		br
 		gzip
-		
+
 		match {
-		    header Content-Type text/*
-		    header Content-Type application/json*
-		    header Content-Type application/javascript*
-		    header Content-Type application/xhtml+xml*
-		    header Content-Type application/atom+xml*
-		    header Content-Type application/rss+xml*
-		    header Content-Type image/svg+xml*
+			header Content-Type text/*
+			header Content-Type application/json*
+			header Content-Type application/javascript*
+			header Content-Type application/xhtml+xml*
+			header Content-Type application/atom+xml*
+			header Content-Type application/rss+xml*
+			header Content-Type image/svg+xml*
 			# Custom formats supported
-		    header Content-Type application/ld+json*
+			header Content-Type application/ld+json*
 		}
 	}
 
@@ -70,13 +70,12 @@
 	# Matches requests for HTML documents, for static files and for Next.js files,
 	# except for known API paths and paths with extensions handled by API Platform
 	@pwa expression `(
-			header({'Accept': '*text/html*'})
-			&& !path(
-				'/docs*', '/graphql*', '/bundles*', '/contexts*', '/_profiler*', '/_wdt*',
-				'*.json*', '*.html', '*.csv', '*.yml', '*.yaml', '*.xml'
-			)
-		)
-		|| path('/favicon.ico', '/manifest.json', '/robots.txt', '/_next*', '/sitemap*')`
+	header({'Accept': '*text/html*'})
+	&& !path(
+	'/docs*', '/graphql*', '/bundles*', '/contexts*', '/_profiler*', '/_wdt*',
+	'*.json*', '*.html', '*.csv', '*.yml', '*.yaml', '*.xml')
+	)
+	|| path('/favicon.ico', '/manifest.json', '/robots.txt', '/_next*', '/sitemap*')`
 
 	# Comment the following line if you don't want Next.js to catch requests for HTML documents.
 	# In this case, they will be handled by the PHP app.


### PR DESCRIPTION
Run `frankenphp fmt /srv/api/frankenphp/Caddyfile -w`
The file contained mixed tabs and spaces and trailing spaces after v3.2.14.
It's also easier to format your code when the template code is already compliant with the formatter.