### PR TITLE
Allow overriding TRUSTED_HOSTS and MERCURE_PUBLIC_URL variables

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -37,7 +37,7 @@ services:
     environment:
       NEXT_PUBLIC_ENTRYPOINT: http://php
 
-  ###> doctrine/doctrine-bundle ###
+###> doctrine/doctrine-bundle ###
   database:
     image: postgres:${POSTGRES_VERSION:-16}-alpine
     environment:
@@ -58,7 +58,7 @@ services:
 volumes:
   caddy_data:
   caddy_config:
-  ###> doctrine/doctrine-bundle ###
+###> doctrine/doctrine-bundle ###
   db_data:
 ###< doctrine/doctrine-bundle ###
 ###> symfony/mercure-bundle ###

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,10 +10,10 @@ services:
       MERCURE_PUBLISHER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
       MERCURE_SUBSCRIBER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
       TRUSTED_PROXIES: ${TRUSTED_PROXIES:-127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16}
-      TRUSTED_HOSTS: ^${SERVER_NAME:-example\.com|localhost}|php$$
+      TRUSTED_HOSTS: ${TRUSTED_HOSTS:-^${SERVER_NAME:-example\.com|localhost}|php$$}
       DATABASE_URL: postgresql://${POSTGRES_USER:-app}:${POSTGRES_PASSWORD:-!ChangeMe!}@database:5432/${POSTGRES_DB:-app}?serverVersion=${POSTGRES_VERSION:-16}&charset=${POSTGRES_CHARSET:-utf8}
       MERCURE_URL: ${CADDY_MERCURE_URL:-http://php/.well-known/mercure}
-      MERCURE_PUBLIC_URL: https://${SERVER_NAME:-localhost}/.well-known/mercure
+      MERCURE_PUBLIC_URL: ${CADDY_MERCURE_PUBLIC_URL:-https://${SERVER_NAME:-localhost}/.well-known/mercure}
       MERCURE_JWT_SECRET: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
     volumes:
       - caddy_data:/data
@@ -37,7 +37,7 @@ services:
     environment:
       NEXT_PUBLIC_ENTRYPOINT: http://php
 
-###> doctrine/doctrine-bundle ###
+  ###> doctrine/doctrine-bundle ###
   database:
     image: postgres:${POSTGRES_VERSION:-16}-alpine
     environment:
@@ -58,7 +58,7 @@ services:
 volumes:
   caddy_data:
   caddy_config:
-###> doctrine/doctrine-bundle ###
+  ###> doctrine/doctrine-bundle ###
   db_data:
 ###< doctrine/doctrine-bundle ###
 ###> symfony/mercure-bundle ###


### PR DESCRIPTION
Modifying the SERVER_NAME to disable HTTPS, as outlined in the [API Platform documentation](https://api-platform.com/docs/deployment/docker-compose/#disabling-https), leads to improper configurations for TRUSTED_HOSTS and MERCURE_PUBLIC_URL when using formats like `http://localhost` or `:80`. 

This results in values like `^:80|php$` or `^http://localhost|php$` for `TRUSTED_HOSTS`, and URLs such as `https://:80/.well-known/mercure` or `https://http://localhost/.well-known/mercure` for `MERCURE_PUBLIC_URL`. 

This PR adopts "nested interpolation" from the [Docker documentation](https://docs.docker.com/compose/compose-file/12-interpolation/) to allow precise overrides, introducing `TRUSTED_PROXIES` and `CADDY_MERCURE_PUBLIC_URL` as new, adjustable variables, with room for naming discussions.