### PR TITLE
fix: remove trusted proxies support

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -14,10 +14,6 @@
 # Run "composer dump-env prod" to compile .env files for production use (requires symfony/flex >=1.2).
 # https://symfony.com/doc/current/best_practices.html#use-environment-variables-for-infrastructure-configuration
 
-# API Platform distribution
-TRUSTED_PROXIES=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
-TRUSTED_HOSTS=^(localhost|php)$
-
 ###> symfony/framework-bundle ###
 APP_ENV=dev
 APP_SECRET=!ChangeMe!

--- a/api/.env.test
+++ b/api/.env.test
@@ -4,6 +4,3 @@ APP_SECRET='$ecretf0rt3st'
 SYMFONY_DEPRECATIONS_HELPER=999999
 PANTHER_APP_ENV=panther
 PANTHER_ERROR_SCREENSHOT_DIR=./var/error-screenshots
-
-# API Platform distribution
-TRUSTED_HOSTS=^example\.com|localhost$

--- a/api/config/packages/framework.yaml
+++ b/api/config/packages/framework.yaml
@@ -6,11 +6,6 @@ framework:
     http_method_override: false
     handle_all_throwables: true
  
-    trusted_proxies: '%env(TRUSTED_PROXIES)%'
-    trusted_hosts: '%env(TRUSTED_HOSTS)%'
-    # See https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#headers
-    trusted_headers: [ 'x-forwarded-for', 'x-forwarded-proto' ]
-
     # Enables session support. Note that the session will ONLY be started if you read or write from it.
     # Remove or comment this section to explicitly disable session support.
     #session:

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,8 +9,6 @@ services:
       SERVER_NAME: ${SERVER_NAME:-localhost}, php:80
       MERCURE_PUBLISHER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
       MERCURE_SUBSCRIBER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
-      TRUSTED_PROXIES: ${TRUSTED_PROXIES:-127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16}
-      TRUSTED_HOSTS: ${TRUSTED_HOSTS:-^${SERVER_NAME:-example\.com|localhost}|php$$}
       DATABASE_URL: postgresql://${POSTGRES_USER:-app}:${POSTGRES_PASSWORD:-!ChangeMe!}@database:5432/${POSTGRES_DB:-app}?serverVersion=${POSTGRES_VERSION:-16}&charset=${POSTGRES_CHARSET:-utf8}
       MERCURE_URL: ${CADDY_MERCURE_URL:-http://php/.well-known/mercure}
       MERCURE_PUBLIC_URL: ${CADDY_MERCURE_PUBLIC_URL:-https://${SERVER_NAME:-localhost}/.well-known/mercure}

--- a/helm/api-platform/templates/configmap.yaml
+++ b/helm/api-platform/templates/configmap.yaml
@@ -8,8 +8,6 @@ data:
   php-app-env: {{ .Values.php.appEnv | quote }}
   php-app-debug: {{ .Values.php.appDebug | quote }}
   php-cors-allow-origin: {{ .Values.php.corsAllowOrigin | quote }}
-  php-trusted-hosts: {{ .Values.php.trustedHosts | quote }}
-  php-trusted-proxies: "{{ join "," .Values.php.trustedProxies }}"
   mercure-url: "http://{{ include "api-platform.fullname" . }}/.well-known/mercure"
   mercure-public-url: {{ .Values.mercure.publicUrl | default "http://127.0.0.1/.well-known/mercure" | quote }}
   mercure-extra-directives: {{ .Values.mercure.extraDirectives | quote }}

--- a/helm/api-platform/templates/deployment.yaml
+++ b/helm/api-platform/templates/deployment.yaml
@@ -50,16 +50,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "api-platform.fullname" . }}
                   key: mercure-jwt-secret
-            - name: TRUSTED_HOSTS
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "api-platform.fullname" . }}
-                  key: php-trusted-hosts
-            - name: TRUSTED_PROXIES
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "api-platform.fullname" . }}
-                  key: php-trusted-proxies
             - name: APP_ENV
               valueFrom:
                 configMapKeyRef:

--- a/helm/api-platform/values.yaml
+++ b/helm/api-platform/values.yaml
@@ -12,12 +12,6 @@ php:
   appDebug: "0"
   appSecret: ""
   corsAllowOrigin: "^https?://.*?\\.chart-example\\.local$"
-  trustedHosts: "^127\\.0\\.0\\.1|localhost|.*\\.chart-example\\.local$"
-  trustedProxies:
-    - "127.0.0.1"
-    - "10.0.0.0/8"
-    - "172.16.0.0/12"
-    - "192.168.0.0/16"
   caddyGlobalOptions: ""
 
 pwa:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | n/a
| License       | MIT
| Doc PR        | todo

This isn't necessary anymore with FrankenPHP when using Docker Compose (there is no proxy anymore).

TODO: handle Kubernetes ingresses properly.