### PR TITLE
chore: do not specify minor version of Dockerfile syntax

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-#syntax=docker/dockerfile:1.4
+#syntax=docker/dockerfile:1
 
 # Adapted from https://github.com/dunglas/symfony-docker
 

--- a/pwa/Dockerfile
+++ b/pwa/Dockerfile
@@ -1,4 +1,4 @@
-#syntax=docker/dockerfile:1.4
+#syntax=docker/dockerfile:1
 
 
 # Versions


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main (but bug fixes [^1])
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

> We recommend using docker/dockerfile:1, which always points to the latest stable release of the version 1 syntax, and receives both "minor" and "patch" updates for the version 1 release cycle.

https://docs.docker.com/build/buildkit/frontend/

Ported from https://github.com/dunglas/symfony-docker/pull/663

[^1]: I did not see the stable branch :(