### PR TITLE
feat: Refine CI docker cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,12 @@ jobs:
             compose.yaml
             compose.override.yaml
           set: |
-            *.cache-from=type=gha,scope=${{github.ref}}
-            *.cache-from=type=gha,scope=refs/heads/main
-            *.cache-to=type=gha,scope=${{github.ref}},mode=max
+            php.cache-from=type=gha,scope=php-${{github.ref}}
+            php.cache-from=type=gha,scope=php-refs/heads/main
+            php.cache-to=type=gha,scope=php-${{github.ref}},mode=max
+            pwa.cache-from=type=gha,scope=pwa-${{github.ref}}
+            pwa.cache-from=type=gha,scope=pwa-refs/heads/main
+            pwa.cache-to=type=gha,scope=pwa-${{github.ref}},mode=max
       -
         name: Start services
         run: docker compose up --wait --no-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,12 @@ jobs:
             compose.yaml
             compose.override.yaml
           set: |
-            *.cache-from=type=gha,scope=${{github.ref}}
-            *.cache-from=type=gha,scope=refs/heads/main
-            *.cache-to=type=gha,scope=${{github.ref}},mode=max
+            php.cache-from=type=gha,scope=php-${{github.ref}}
+            php.cache-from=type=gha,scope=php-refs/heads/main
+            php.cache-to=type=gha,scope=php-${{github.ref}},mode=max
+            pwa.cache-from=type=gha,scope=pwa-${{github.ref}}
+            pwa.cache-from=type=gha,scope=pwa-refs/heads/main
+            pwa.cache-to=type=gha,scope=pwa-${{github.ref}},mode=max
       -
         name: Update API Platform
         run: docker compose run php composer update api-platform/core:${{ inputs.tag }}


### PR DESCRIPTION
Refine CI docker cache handling, and obtain 100% cache hit during containers building.

While playing with [docker bake action](https://github.com/docker/bake-action) and github action based docker build layer cache, i've struggled a bit to discover that, in case of a multi target baking,  *every* target *must* have its own scope (see: https://github.com/docker/bake-action/issues/91#issuecomment-1265817118).

As this repo uses 2 targets, i've just used them as a prefix for each target cache scope:
```shell
$ docker buildx bake -f compose.yaml -f compose.override.yaml --print
...
{
  "group": {
    "default": {
      "targets": [
        "php",
        "pwa"
      ]
    }
  },
...
```


