### PR TITLE
Support overriding exposed database port numbmer

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -37,7 +37,7 @@ services:
   database:
     ports:
       - target: 5432
-        published: 5432
+        published: ${DB_PORT:-5432}
         protocol: tcp
 ###< doctrine/doctrine-bundle ###
 


### PR DESCRIPTION
This adds support to specify the DB_PORT env var in order to be able to override the exposed database service port number.

| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

This just makes the database service's exposed port use the DB_PORT environment variable if provided.

This allows people running multiple Docker Postgres services on thier machine an easy way to provide a custom
port number to avoid conflicts with existing, running Postgres service containers.

I've not submitted a docs PR as I don't think that the Docker *_PORT env vars are currently included in the docs from a quick search.

I have not added a test for this yet, but please let me know if you need one and I'll try to work out how to add one.

I cannot see a CHANGELOG in this project root to update with this change, as instructed int he PR template.