### PR TITLE
Prefer latest corepack to prevent initial build error

### DIFF
--- a/pwa/Dockerfile
+++ b/pwa/Dockerfile
@@ -14,7 +14,8 @@ RUN apk add --no-cache libc6-compat
 
 WORKDIR /srv/app
 
-RUN corepack enable && \
+RUN npm install -g corepack@latest && \
+    corepack enable && \
 	corepack prepare --activate pnpm@latest && \
 	pnpm config -g set store-dir /.pnpm-store
 


### PR DESCRIPTION
When running `docker compose up` on a fresh installation, the node image and corepack version result in an "Cannot find matching keyid" error. Ensuring the latest corepack version resolves this.

| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | -
| License       | MIT
| Doc PR        | N/A

Creating a new repo with the current `main` state of this repo - by using [Github's green "use this template" button](https://github.com/api-platform/api-platform) - results in a build error when running `docker compose up`.

The following guide by Vercel suggests having the latest corepack version to resolve the error above: https://vercel.com/guides/corepack-errors-github-actions#quick-debug-steps

<img width="1338" alt="image" src="https://github.com/user-attachments/assets/458045d2-aa86-4ac6-ac36-7cbad793703f" />

### My stack:

Macbook M1
Docker v4.38.0 (181591) 

