### PR TITLE
Fix Docker build FromAsCasing mismatch warning

### DIFF
--- a/pwa/Dockerfile
+++ b/pwa/Dockerfile
@@ -22,7 +22,7 @@ ENV NEXT_TELEMETRY_DISABLED 1
 
 
 # Development image
-FROM base as dev
+FROM base AS dev
 
 EXPOSE 3000
 ENV PORT 3000


### PR DESCRIPTION
FromAsCasing mismatch on AS and FROM keywords.

Docker build output:

<img width="690" alt="image" src="https://github.com/user-attachments/assets/af1e0a36-74a7-4dcd-8030-32031e7c86dc" />

| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | -
| License       | MIT
| Doc PR        | -
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 3.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
