### PR TITLE
fix: Update build target for php image in skaffold.yaml

### DIFF
--- a/helm/skaffold.yaml
+++ b/helm/skaffold.yaml
@@ -7,7 +7,7 @@ build:
     - image: api-platform-php
       context: ../api
       docker:
-        target: app_php
+        target: frankenphp_dev
     - image: api-platform-pwa
       context: ../pwa
       docker:

--- a/helm/skaffold.yaml
+++ b/helm/skaffold.yaml
@@ -7,7 +7,7 @@ build:
     - image: api-platform-php
       context: ../api
       docker:
-        target: frankenphp_dev
+        target: frankenphp_prod
     - image: api-platform-pwa
       context: ../pwa
       docker:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | (unable to find stable/latest branch to target as advised, so `main`?branch for bug fixes <!-- see below -->
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Running `skaffold dev` was failing due to the build target not being found.  This appears to be because the target was renamed from `app_php` to `frankenphp_dev`.

I can only see `main` `api-platform-core` and `php-fpm` branches for targeting this PR, so unsure if this is correct based on the PR template advice.  Sorry if this is incorrect.

Also, I cannot see the CHANGELOG.md file that I'm advised to update.

I'm not sure if this reuqires tests, but please advise if it does, and where I might add these?