### PR TITLE
fix: Correctly assign existing group ID to nextjs user

### DIFF
--- a/pwa/Dockerfile
+++ b/pwa/Dockerfile
@@ -52,7 +52,7 @@ ENV NODE_ENV production
 ENV NEXT_TELEMETRY_DISABLED 1
 
 RUN addgroup --gid 1001 nodejs; \
-	adduser --uid 1001 nextjs
+	adduser --uid 1001 --gid 1001 nextjs
 
 COPY --from=builder --link /srv/app/public ./public
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main as unable to find a stable/latest branch to target
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Updates the `adduser` command to specify the user's group ID.

Prior to this change, the build fails with error that group with ID 1001 already exists.

Sorry.  I'm unable to find stable/latest branch to target. Or the CHANGELOG.md file to update.