### PR TITLE
chore: remove useless git checkout in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           pull: true
           load: true
+          source: .
           files: |
             compose.yaml
             compose.override.yaml


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Backport of https://github.com/dunglas/symfony-docker/pull/862