### PR TITLE
chore: Delete obsolete worker config file

### DIFF
--- a/api/frankenphp/worker.Caddyfile
+++ b/api/frankenphp/worker.Caddyfile
@@ -1,4 +1,0 @@
-worker {
-	file ./public/index.php
-	env APP_RUNTIME Runtime\FrankenPhpSymfony\Runtime
-}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main 
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

This file is unnecessary, as the config for the worker is now in the Caddyfile. 
The build fails with this file.