### PR TITLE
Update CORS configuration in nelmio_cors.yaml

### DIFF
--- a/api/config/packages/nelmio_cors.yaml
+++ b/api/config/packages/nelmio_cors.yaml
@@ -2,9 +2,19 @@ nelmio_cors:
     defaults:
         origin_regex: true
         allow_origin: ['%env(CORS_ALLOW_ORIGIN)%']
+        #allow_credentials: true #Only when security cookies are used
         allow_methods: ['GET', 'OPTIONS', 'POST', 'PUT', 'PATCH', 'DELETE']
-        allow_headers: ['Content-Type', 'Authorization', 'Preload', 'Fields']
-        expose_headers: ['Link']
-        max_age: 3600
+        allow_headers: [
+            'Content-Type', 'Authorization', 'Accept', 'Fields',
+            'Preload', 'Prefer', 'Cache-Control', 'X-Requested-With',
+            'If-Match', 'If-None-Match' # For ETag support
+        ]
+        expose_headers: [
+            'Link', 'X-Total-Count', 'ETag', 'Location',
+            'Content-Location', 'Content-Range'
+        ]
+        max_age: 86400
+        forced_allow_origin_value: ~
+
     paths:
-        '^/': null
+        '^/': ~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | none
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

Extended allowed CORS headers to include:
- Added `If-Match` and `If-None-Match` to allow conditional requests (ETag-based updates)
- Extended exposed headers (`ETag`, `Location`, `Content-Location`, `Content-Range`) for
  pagination, cache validation and resource discovery
- Added `Accept`, `Prefer`, `Cache-Control` and `X-Requested-With` to reduce unnecessary
  preflight requests and improve compatibility with fetch-based clients
- Left `forced_allow_origin_value` unset for standard origin reflection

Commented `allow_credentials`. To be enabled only when using secure cookies