### PR TITLE
Add gitignore to Symfony admin scaffold

### DIFF
--- a/src/Scaffold/SymfonyAdminScaffold.php
+++ b/src/Scaffold/SymfonyAdminScaffold.php
@@ -19,6 +19,7 @@ final class SymfonyAdminScaffold
     private const TEMPLATE_FILES = [
         // template name => destination relative to admin/
         'admin-index.html' => 'index.html',
+        'admin-gitignore' => '.gitignore',
         'admin-package.json' => 'package.json',
         'admin-vite.config.ts' => 'vite.config.ts',
         'admin-tsconfig.json' => 'tsconfig.json',

--- a/templates/admin-gitignore
+++ b/templates/admin-gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.local

--- a/tests/Scaffold/SymfonyAdminScaffoldTest.php
+++ b/tests/Scaffold/SymfonyAdminScaffoldTest.php
@@ -13,6 +13,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class SymfonyAdminScaffoldTest extends TestCase
 {
+    private const ADMIN_GITIGNORE_TEMPLATE = 'admin-gitignore';
+    private const ADMIN_GITIGNORE_DESTINATION = '.gitignore';
+
     public function testAppendsViteEntrypointEnvWhenAbsent(): void
     {
         $patched = SymfonyAdminScaffold::appendEntrypointEnv('', 'https://localhost');
@@ -45,6 +48,14 @@ final class SymfonyAdminScaffoldTest extends TestCase
         $this->assertFileExists(Templates::path('admin-package.json'));
         $this->assertFileExists(Templates::path('admin-vite.config.ts'));
         $this->assertFileExists(Templates::path('admin-tsconfig.json'));
+        $this->assertFileExists(Templates::path(self::ADMIN_GITIGNORE_TEMPLATE));
+    }
+
+    public function testAdminScaffoldCopiesGitignoreTemplate(): void
+    {
+        $templates = (new \ReflectionClass(SymfonyAdminScaffold::class))->getConstant('TEMPLATE_FILES');
+
+        $this->assertSame(self::ADMIN_GITIGNORE_DESTINATION, $templates[self::ADMIN_GITIGNORE_TEMPLATE] ?? null);
     }
 
     public function testAdminPackageJsonPinsCriticalDeps(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #2998
| License       | MIT
| Doc PR        | n/a

## Summary

This adds a `.gitignore` template to the standalone Symfony React-admin scaffold so generated `admin/node_modules/`, `admin/dist/`, and local env overrides are not accidentally committed.

## Test verification (RED → GREEN)

RED, before the fix, after adding the regression test:

```text
...FF...                                                            8 / 8 (100%)

1) ApiPlatform\Installer\Tests\Scaffold\SymfonyAdminScaffoldTest::testAdminTemplatesAreShippedWithTheInstaller
Failed asserting that file "/app/templates/admin-gitignore" exists.

2) ApiPlatform\Installer\Tests\Scaffold\SymfonyAdminScaffoldTest::testAdminScaffoldCopiesGitignoreTemplate
Failed asserting that null is identical to '.gitignore'.

FAILURES!
Tests: 8, Assertions: 24, Failures: 2.
```

GREEN, with the fix:

```text
...............................................................  63 / 109 ( 57%)
..............................................                  109 / 109 (100%)

OK (109 tests, 220 assertions)
```

Fix-reverted regression check:

```text
....F...                                                            8 / 8 (100%)

ApiPlatform\Installer\Tests\Scaffold\SymfonyAdminScaffoldTest::testAdminScaffoldCopiesGitignoreTemplate
Failed asserting that null is identical to '.gitignore'.

FAILURES!
Tests: 8, Assertions: 24, Failures: 1.
```

Static analysis:

```text
php vendor/bin/phpstan analyse
[OK] No errors
```

All commands were run inside an ephemeral Docker container with `docker run --rm -u "$(id -u):$(id -g)" -v "$PWD":/app -w /app composer:2 ...`.
