### PR TITLE
Copy devcontainer from Symfony Docker scaffold

### DIFF
--- a/src/Scaffold/SymfonyScaffold.php
+++ b/src/Scaffold/SymfonyScaffold.php
@@ -22,6 +22,7 @@ final class SymfonyScaffold
         'compose.yaml',
         'compose.override.yaml',
         'compose.prod.yaml',
+        '.devcontainer',
         'frankenphp',
     ];
     private const KNOWN_FORMATS = [

--- a/tests/Scaffold/SymfonyScaffoldTest.php
+++ b/tests/Scaffold/SymfonyScaffoldTest.php
@@ -14,6 +14,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class SymfonyScaffoldTest extends TestCase
 {
+    private const DEVCONTAINER_DIR = '.devcontainer';
+
     public function testGreetingsTemplateOnlyDeclaresWorkingCollectionOperation(): void
     {
         $template = (string) file_get_contents(Templates::path('Greetings.php'));
@@ -56,6 +58,13 @@ final class SymfonyScaffoldTest extends TestCase
         // A floating ref (branch name) means every install would track upstream
         // HEAD; pinning to a 40-char SHA-1 guarantees reproducible scaffolds.
         $this->assertMatchesRegularExpression('/^[0-9a-f]{40}$/', SymfonyScaffold::SYMFONY_DOCKER_REF);
+    }
+
+    public function testSymfonyDockerCopyListIncludesDevcontainer(): void
+    {
+        $dockerFiles = (new \ReflectionClass(SymfonyScaffold::class))->getConstant('DOCKER_FILES');
+
+        $this->assertContains(self::DEVCONTAINER_DIR, $dockerFiles);
     }
 
     public function testDisablesAllUiViewersWhenEmptyButKeepsHydraDocs(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | Refs #2994
| License       | MIT
| Doc PR        | n/a

## Summary

This copies the `.devcontainer` directory from the pinned `dunglas/symfony-docker` snapshot when `--with-docker` is used.

## Scope choice for #2994

The issue mentions several possible migration gaps from the old template:

- A. Copy the upstream `.devcontainer` directory from `symfony-docker`.
- B. Add Docker Compose services for the generated PWA/admin apps.
- C. Add an explicit database service/configuration to the generated compose setup.
- D. Reintroduce or generate Helm chart assets.

This PR chooses A because the installer already imports Docker infrastructure from a pinned `symfony-docker` commit, and that same pinned snapshot contains `.devcontainer`. Copying it keeps ownership with the upstream Docker template and avoids inventing local PWA/admin/Postgres/Helm behavior before maintainers agree on those larger choices.

## Test verification (RED → GREEN)

RED, before the fix, after adding the regression test:

```text
...F...                                                             7 / 7 (100%)

1) ApiPlatform\Installer\Tests\Scaffold\SymfonyScaffoldTest::testSymfonyDockerCopyListIncludesDevcontainer
Failed asserting that an array contains '.devcontainer'.

FAILURES!
Tests: 7, Assertions: 15, Failures: 1.
```

GREEN, with the fix:

```text
...............................................................  63 / 109 ( 57%)
..............................................                  109 / 109 (100%)

OK (109 tests, 219 assertions)
```

Fix-reverted regression check:

```text
...F...                                                             7 / 7 (100%)

ApiPlatform\Installer\Tests\Scaffold\SymfonyScaffoldTest::testSymfonyDockerCopyListIncludesDevcontainer
Failed asserting that an array contains '.devcontainer'.

FAILURES!
Tests: 7, Assertions: 15, Failures: 1.
```

Static analysis:

```text
php vendor/bin/phpstan analyse
[OK] No errors
```

All commands were run inside ephemeral Docker containers with `docker run --rm -u "$(id -u):$(id -g)" -v "$PWD":/app -w /app composer:2 ...`.
