### PR TITLE
fix(installer): remove conflicting Greetings item route

### DIFF
--- a/templates/Greetings.php
+++ b/templates/Greetings.php
@@ -3,13 +3,11 @@
 namespace App\ApiResource;
 
 use ApiPlatform\Metadata\ApiResource;
-use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use Symfony\Component\Serializer\Attribute\Groups;
 
 #[ApiResource(
     operations: [
-        new Get(),
         new GetCollection(
             provider: Greetings::class . '::provide',
         ),

--- a/tests/Scaffold/SymfonyScaffoldTest.php
+++ b/tests/Scaffold/SymfonyScaffoldTest.php
@@ -6,6 +6,7 @@ namespace ApiPlatform\Installer\Tests\Scaffold;
 
 use ApiPlatform\Installer\Scaffold\ScaffoldOptions;
 use ApiPlatform\Installer\Scaffold\SymfonyScaffold;
+use ApiPlatform\Installer\Templates;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -13,6 +14,16 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class SymfonyScaffoldTest extends TestCase
 {
+    public function testGreetingsTemplateOnlyDeclaresWorkingCollectionOperation(): void
+    {
+        $template = (string) file_get_contents(Templates::path('Greetings.php'));
+
+        $this->assertStringContainsString('new GetCollection(', $template);
+        $this->assertStringContainsString("provider: Greetings::class . '::provide'", $template);
+        $this->assertStringNotContainsString('new Get()', $template);
+        $this->assertStringNotContainsString('use ApiPlatform\\Metadata\\Get;', $template);
+    }
+
     public function testEnablesSelectedDocsAndDisablesOthers(): void
     {
         $config = SymfonyScaffold::buildApiPlatformConfig(new ScaffoldOptions(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #3003
| License       | MIT
| Doc PR        | no

## Summary

The generated `Greetings` resource declares both `Get` and `GetCollection` without URI variables, so both map to `/greetings`. The item route is matched first and returns 404 before the collection provider runs.

This removes the unused item operation and its import, and adds a regression test that keeps the template collection-only.

Fixes #3003.

## Tests

- `vendor/bin/phpunit` (109 tests, 222 assertions)
- `php -d memory_limit=512M vendor/bin/phpstan analyse --no-progress`
- `composer validate --strict --no-check-publish`
- PHAR build plus `--version` and `--help`
- Fresh Symfony scaffold: `GET /greetings.jsonld` returns 200 with `hello: "World!"`
